### PR TITLE
Support rapidjson and ujson libs for better sync performance.

### DIFF
--- a/docs/HOWTO.rst
+++ b/docs/HOWTO.rst
@@ -69,8 +69,12 @@ was much worse.
 
 You will need to install one of:
 
-+ `plyvel <https://plyvel.readthedocs.io/en/latest/installation.html>`_ for LevelDB
-+ `python-rocksdb <https://pypi.python.org/pypi/python-rocksdb>`_ for RocksDB (`pip3 install python-rocksdb`)
++ `plyvel <https://plyvel.readthedocs.io/en/latest/installation.html>`_ for LevelDB.
+
+  Included as part of a regular pip or ``setup.py`` installation of ElectrumX.
++ `python-rocksdb <https://pypi.python.org/pypi/python-rocksdb>`_ for RocksDB
+
+  ``pip3 install python-rocksdb`` or use the rocksdb extra install option to ElectrumX.
 + `pyrocksdb <http://pyrocksdb.readthedocs.io/en/v0.4/installation.html>`_ for an unmaintained version that doesn't work with recent releases of RocksDB
 
 Running
@@ -83,8 +87,20 @@ Check out the code from Github::
     git clone https://github.com/spesmilo/electrumx.git
     cd electrumx
 
-You can install with :file:`setup.py` or run the code from the source
-tree or a copy of it.
+You can install with::
+
+    pip3 install .
+
+There are many extra Python dependencies available to fit the needs of your
+system or coins. For example, to install the RocksDB dependencies and a faster
+JSON parsing library::
+
+    pip3 install .[rocksdb,ujson]
+
+see setup.py's ``extra_requires`` for a complete list.
+
+You can also run the code from the source tree or a copy of it.
+
 
 You should create a standard user account to run the server under;
 your own is probably adequate unless paranoid.  The paranoid might

--- a/docs/PERFORMANCE-NOTES
+++ b/docs/PERFORMANCE-NOTES
@@ -34,3 +34,12 @@ account in the code.
 
 - retrieving a previously stored length of a bytes object can be over 200%
   faster than a new call to len(b)
+
+- The cpython and pypy stdlibs use a Python-based JSON serializer/deserializer,
+  which is stable and easy to use and install, but much slower than
+  system-compiled variants. ElectrumX now looks for either of the popular
+  C-based JSON libraries for Python, python-rapidjson or ujson. If it finds
+  one, it's used instead of the stdlib module for improved performance.
+
+  To install a known-compatible system-compiled JSON lib, install ElectrumX
+  with either the "rapidjson" or "ujson" extras parameter.

--- a/electrumx/lib/util.py
+++ b/electrumx/lib/util.py
@@ -37,6 +37,18 @@ from collections.abc import Container, Mapping
 from struct import Struct
 
 
+# Use system-compiled JSON lib if available, fallback to stdlib
+try:
+    import rapidjson as json
+except ImportError:
+    try:
+        import ujson as json
+    except ImportError:
+        import json
+
+json_deserialize = json.loads
+json_serialize = json.dumps
+
 # Logging utilities
 
 

--- a/electrumx/server/peers.py
+++ b/electrumx/server/peers.py
@@ -8,21 +8,20 @@
 '''Peer management.'''
 
 import asyncio
-from ipaddress import IPv4Address, IPv6Address
-import json
 import random
 import socket
 import ssl
 import time
-from collections import defaultdict, Counter
+from collections import Counter, defaultdict
+from ipaddress import IPv4Address, IPv6Address
 
 import aiohttp
-from aiorpcx import (connect_rs, RPCSession, SOCKSProxy, Notification, handler_invocation,
-                     SOCKSError, RPCError, TaskTimeout, TaskGroup, Event,
-                     sleep, ignore_after)
+from aiorpcx import (Event, Notification, RPCError, RPCSession, SOCKSError,
+                     SOCKSProxy, TaskGroup, TaskTimeout, connect_rs,
+                     handler_invocation, ignore_after, sleep)
 
 from electrumx.lib.peer import Peer
-from electrumx.lib.util import class_logger
+from electrumx.lib.util import class_logger, json_deserialize
 
 PEER_GOOD, PEER_STALE, PEER_NEVER, PEER_BAD = range(4)
 STALE_SECS = 3 * 3600
@@ -143,7 +142,7 @@ class PeerManager:
             async with aiohttp.ClientSession() as session:
                 async with session.get(url) as response:
                     text = await response.text()
-            return set(entry.lower() for entry in json.loads(text))
+            return set(entry.lower() for entry in json_deserialize(text))
 
         while True:
             try:

--- a/electrumx/server/session.py
+++ b/electrumx/server/session.py
@@ -10,7 +10,6 @@
 import codecs
 import datetime
 import itertools
-import json
 import math
 import os
 import ssl
@@ -20,21 +19,19 @@ from functools import partial
 from ipaddress import IPv4Address, IPv6Address
 
 import attr
-from aiorpcx import (
-    RPCSession, JSONRPCAutoDetect, JSONRPCConnection, serve_rs, serve_ws,
-    TaskGroup, handler_invocation, RPCError, Request, sleep, Event, ReplyAndDisconnect
-)
 import pylru
+from aiorpcx import (Event, JSONRPCAutoDetect, JSONRPCConnection,
+                     ReplyAndDisconnect, Request, RPCError, RPCSession,
+                     TaskGroup, handler_invocation, serve_rs, serve_ws, sleep)
 
 import electrumx
+import electrumx.lib.util as util
+from electrumx.lib.hash import (HASHX_LEN, Base58Error, hash_to_hex_str,
+                                hex_str_to_hash, sha256)
 from electrumx.lib.merkle import MerkleCache
 from electrumx.lib.text import sessions_lines
-import electrumx.lib.util as util
-from electrumx.lib.hash import (sha256, hash_to_hex_str, hex_str_to_hash,
-                                HASHX_LEN, Base58Error)
 from electrumx.server.daemon import DaemonError
 from electrumx.server.peers import PeerManager
-
 
 BAD_REQUEST = 1
 DAEMON_ERROR = 2
@@ -234,7 +231,7 @@ class SessionManager:
                 data = self._session_data(for_log=True)
                 for line in sessions_lines(data):
                     self.logger.info(line)
-                self.logger.info(json.dumps(self._get_info()))
+                self.logger.info(util.json_serialize(self._get_info()))
 
     async def _disconnect_sessions(self, sessions, reason, *, force_after=1.0):
         if sessions:

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,9 @@ setuptools.setup(
     install_requires=['aiorpcX[ws]>=0.18.3,<0.19', 'attrs',
                       'plyvel', 'pylru', 'aiohttp>=3.3'],
     extras_require={
+        'rapidjson': ['python-rapidjson>=0.4.1,<1.0.0'],
         'rocksdb': ['python-rocksdb>=0.6.9'],
+        'ujson': ['ujson>=2.0.0,<4.0.0'],
         'uvloop': ['uvloop>=0.14'],
         # For various coins
         'blake256': ['blake256>=0.1.1'],

--- a/tests/server/test_daemon.py
+++ b/tests/server/test_daemon.py
@@ -54,14 +54,14 @@ class JSONResponse(ResponseBase):
         self.result = result
         self.msg_id = msg_id
 
-    async def json(self):
+    async def json(self, loads=json.loads):
         if isinstance(self.msg_id, int):
             message = JSONRPCv1.response_message(self.result, self.msg_id)
         else:
             parts = [JSONRPCv1.response_message(item, msg_id)
                      for item, msg_id in zip(self.result, self.msg_id)]
             message = JSONRPCv1.batch_message_from_parts(parts)
-        return json.loads(message.decode())
+        return loads(message.decode())
 
 
 class HTMLResponse(ResponseBase):


### PR DESCRIPTION
This adds ujson and python-rapidjson support. If either are found in the Python environment, they are used instead of the stdlib json library where possible. To ease installation of a compatible version of either library, "ujson" and "rapidjson" extras strings are available for the install:

    pip3 install .[rapidjson]

This was work was split from spesmilo/electrumx#10.