### PR TITLE
docs: fix blockchain.scripthash.get_balance return value

### DIFF
--- a/docs/protocol-methods.rst
+++ b/docs/protocol-methods.rst
@@ -276,15 +276,15 @@ Return the confirmed and unconfirmed balances of a :ref:`script hash
 **Result**
 
   A dictionary with keys `confirmed` and `unconfirmed`.  The value of
-  each is the appropriate balance in coin units as a string.
+  each is the appropriate balance in minimum coin units (satoshis).
 
 **Result Example**
 
 ::
 
   {
-    "confirmed": "1.03873966",
-    "unconfirmed": "0.236844"
+    "confirmed": 103873966,
+    "unconfirmed": 23684400
   }
 
 blockchain.scripthash.get_history


### PR DESCRIPTION
The docs and the actual behaviour are inconsistent. Which one do we fix?
The Electrum client expects the current behaviour, so we fix the docs.

see https://github.com/spesmilo/electrumx/blob/10616105b9ca2fc013dd3b0efbc46db7e847a382/electrumx/server/session.py#L1084-L1089