### PR TITLE
Remove time-based groups

### DIFF
--- a/docs/rpc-interface.rst
+++ b/docs/rpc-interface.rst
@@ -137,8 +137,7 @@ connected, the number of unprocessed requests should be low, say 250 or fewer.  
 over 1,000 the server is overloaded.
 
 Sessions are put into groups, primarily as an anti-DoS measure. Each session goes into
-a group based on it's IP address subnet (the first three numbers). Example: session from
-IP 192.168.1.23 goes into group "192.168.1". Each member of a group incurs a fraction 
+a group based on its IP subnet (e.g. /24 for IPv4). Each member of a group incurs a fraction
 of the costs of the other group members. This appears in the `sessions_` list under the
 column XCost.
 

--- a/docs/rpc-interface.rst
+++ b/docs/rpc-interface.rst
@@ -136,10 +136,11 @@ Apart from very short intervals, typically after a new block or when a client ha
 connected, the number of unprocessed requests should be low, say 250 or fewer.  If it is
 over 1,000 the server is overloaded.
 
-Sessions are put into groups, primarily as an anti-DoS measure.  Currently each session
-goes into two groups: one for an IP subnet, and one based on the timeslice it connected
-in.  Each member of a group incurs a fraction of the costs of the other group members.
-This appears in the `sessions_` list under the column XCost.
+Sessions are put into groups, primarily as an anti-DoS measure. Each session goes into
+a group based on it's IP address subnet (the first three numbers). Example: session from
+IP 192.168.1.23 goes into group "192.168.1". Each member of a group incurs a fraction 
+of the costs of the other group members. This appears in the `sessions_` list under the
+column XCost.
 
 groups
 ------

--- a/electrumx/server/session.py
+++ b/electrumx/server/session.py
@@ -804,9 +804,6 @@ class SessionManager:
             return ':'.join(host.exploded.split(':')[:3])  # /48
         return 'unknown_addr'
 
-    def _timeslice_name(self, session):
-        return f't{int(session.start_time - self.start_time) // 300}'
-
     def _session_group(self, name: Optional[str], weight: float) -> Optional[SessionGroup]:
         if name is None:
             return None
@@ -820,7 +817,6 @@ class SessionManager:
         self.session_event.set()
         # Return the session groups
         groups = (
-            self._session_group(self._timeslice_name(session), 0.03),
             self._session_group(self._ip_addr_group_name(session), 1.0),
         )
         groups = (group for group in groups if group is not None)


### PR DESCRIPTION
Removes time-based groups, because they are ineffective and in fact prevent the usage of anti-ddos mechanisms. Fixes #26 