### PR TITLE
Added IPv6-only litecoin testnet electrum instance

### DIFF
--- a/electrumx/lib/coins.py
+++ b/electrumx/lib/coins.py
@@ -989,6 +989,7 @@ class LitecoinTestnet(Litecoin):
     PEERS = [
         'electrum-ltc.bysh.me s t',
         'electrum.ltc.xurious.com s t',
+        'ipv6-only.electrum.random.re s t',
     ]
 
 


### PR DESCRIPTION
We need at least one IPv6 host running. It is mine 👍