### PR TITLE
session: allow clients to query server.version after negotitation

### DIFF
--- a/docs/protocol-changes.rst
+++ b/docs/protocol-changes.rst
@@ -147,6 +147,8 @@ Removed methods
   * :func:`blockchain.block.get_header`
   * :func:`blockchain.block.get_chunk`
 
+.. _version 1.4.1:
+
 Version 1.4.1
 =============
 
@@ -158,11 +160,18 @@ Changes
     nonzero.  AuxPoW data is still present when *cp_height* is zero.
     Non-AuxPoW chains are unaffected.
 
-
-Version 1.4.1
-=============
-
 New methods
 -----------
 
   * :func:`blockchain.scipthash.unsubscribe` to unsubscribe from a script hash.
+
+.. _version 1.4.2:
+
+Version 1.4.2
+=============
+
+Changes
+-------
+
+  * :func:`server.version` now always reports the current versions in use;
+    however, only the first message performs protocol negotiation.

--- a/docs/protocol-methods.rst
+++ b/docs/protocol-methods.rst
@@ -968,7 +968,9 @@ server.version
 ==============
 
 Identify the client to the server and negotiate the protocol version.
-Only the first :func:`server.version` message is accepted.
+The first :func:`server.version` message performs the protocol version
+negotiation as described below. Subsequent calls simply return the negotiated
+version.
 
 **Signature**
 

--- a/electrumx/server/session.py
+++ b/electrumx/server/session.py
@@ -1337,7 +1337,7 @@ class ElectrumX(SessionBase):
         '''
         self.bump_cost(0.5)
         if self.sv_seen:
-            raise RPCError(BAD_REQUEST, f'server.version already sent')
+            return electrumx.version, self.protocol_version_string()
         self.sv_seen = True
 
         if client_name:


### PR DESCRIPTION
There's no reason why the server wouldn't want to report its software
and protocol versions after the negotiation. This can be used, for
example, by a stateless client.

This is backwards compatible.