### PR TITLE
docs: describe protocol version 2.0

### DIFF
--- a/docs/protocol-basics.rst
+++ b/docs/protocol-basics.rst
@@ -162,7 +162,7 @@ txid (in network byteorder) is used to arrive at a canonical ordering.
     (reverse of human display endianness)
 
   * ``height`` is the height of the block the tx is included in,
-    serialised as 8-bytes, little-endian, signed (two's complement)
+    serialised as 4-bytes, little-endian, signed (two's complement)
 
 6. For each mempool tx, form a bytearray: ``tx_hash+height+fee``, where:
 
@@ -170,7 +170,7 @@ txid (in network byteorder) is used to arrive at a canonical ordering.
     (reverse of human display endianness)
 
   * ``height`` is either ``0`` or ``-1``, as defined above,
-    serialised as 8-bytes, little-endian, signed (two's complement)
+    serialised as 4-bytes, little-endian, signed (two's complement)
 
   * ``fee`` is the transaction fee in minimum coin units (satoshis),
     serialised as 8-bytes, little-endian, unsigned
@@ -185,7 +185,7 @@ txid (in network byteorder) is used to arrive at a canonical ordering.
   If the history contains ``n`` txs, the status is ``status_n``. The ``tx_n``
   series consists of, first the confirmed txs touching the script hash,
   followed by the mempool txs touching it; formatted as described above, as
-  bytearrays of length 40 or 48.
+  bytearrays of length 36 or 44.
 
 
 Old Status (before protocol 1.5)

--- a/docs/protocol-basics.rst
+++ b/docs/protocol-basics.rst
@@ -136,7 +136,7 @@ block public key.
 
 .. _status:
 
-Status (protocol 1.5 and later)
+Status (protocol 2.0 and later)
 -------------------------------
 
 To calculate the `status` of a :ref:`script hash <script hashes>` (or
@@ -188,7 +188,7 @@ txid (in network byteorder) is used to arrive at a canonical ordering.
   bytearrays of length 36 or 44.
 
 
-Old Status (before protocol 1.5)
+Old Status (before protocol 2.0)
 --------------------------------
 
 To calculate the `status` of a :ref:`script hash <script hashes>` (or

--- a/docs/protocol-changes.rst
+++ b/docs/protocol-changes.rst
@@ -2,7 +2,7 @@
 Protocol Changes
 ================
 
-This documents lists changes made by protocol version.
+This document lists changes made by protocol version.
 
 Version 1.0
 ===========
@@ -175,3 +175,33 @@ New methods
 -----------
 
   * :func:`blockchain.name.get_value_proof` to resolve a name (with proof).  Name index coins (e.g. Namecoin) only.
+
+
+.. _version 1.5:
+
+Version 1.5
+===========
+
+Changes
+-------
+
+  * Breaking change for the version negotiation: we now mandate that
+    the :func:`server.version` message must be the first message sent.
+    That is, version negotiation must happen before any other messages.
+  * The status of a scripthash has been re-defined. The new definition is
+    recursive and makes it possible not to redo all hashing for most
+    updates.
+  * :func:`blockchain.scripthash.get_history` changed significantly to
+    allow pagination of long histories.
+  * :func:`blockchain.scripthash.get_mempool` previously did not define
+    an order for mempool transactions. We now mandate a specific ordering.
+  * The previously required *height* argument for
+    :func:`blockchain.transaction.get_merkle` is now optional.
+  * Optional *mode* argument added to :func:`blockchain.estimatefee`.
+
+New methods
+-----------
+
+  * :func:`blockchain.outpoint.subscribe` to subscribe to a transaction
+    outpoint, and get a notification when it gets spent.
+  * :func:`blockchain.outpoint.unsubscribe` to unsubscribe from a TXO.

--- a/docs/protocol-changes.rst
+++ b/docs/protocol-changes.rst
@@ -198,6 +198,8 @@ Changes
   * The previously required *height* argument for
     :func:`blockchain.transaction.get_merkle` is now optional.
   * Optional *mode* argument added to :func:`blockchain.estimatefee`.
+  * :func:`blockchain.block.headers` now returns headers as a list,
+    instead of a single concatenated hex string.
 
 New methods
 -----------

--- a/docs/protocol-changes.rst
+++ b/docs/protocol-changes.rst
@@ -177,9 +177,9 @@ New methods
   * :func:`blockchain.name.get_value_proof` to resolve a name (with proof).  Name index coins (e.g. Namecoin) only.
 
 
-.. _version 1.5:
+.. _version 2.0:
 
-Version 1.5
+Version 2.0
 ===========
 
 Changes

--- a/docs/protocol-methods.rst
+++ b/docs/protocol-methods.rst
@@ -611,6 +611,12 @@ as an input (spends it).
     Note that some implementations (such as EPS/BWT) might require this parameter
     to be able to serve the request.
 
+.. note::  The server MAY automatically clean up subscriptions (unsubscribe the client)
+  where the spending transaction is already deeply mined at a reorg-safe height (typically
+  100+ blocks deep).
+  Similarly, the server MAY ignore new subscription requests if the spending tx is already
+  mined at a reorg-safe height but it still MUST send at least one full response.
+
 **Result**
 
   The status of the TXO, taking the mempool into consideration.

--- a/docs/protocol-methods.rst
+++ b/docs/protocol-methods.rst
@@ -172,7 +172,9 @@ be confirmed within a certain number of blocks.
   *mode*
 
     A string to pass to the bitcoind *estimatesmartfee* RPC as the
-    *estimate_mode* parameter. Optional.
+    *estimate_mode* parameter. Optional. If omitted, the corresponding
+    parameter to the bitcoind RPC is also omitted, i.e. the default
+    value is determined by bitcoind.
 
 **Result**
 
@@ -577,7 +579,7 @@ as an input (spends it).
 
 **Signature**
 
-  .. function:: blockchain.outpoint.subscribe(tx_hash, txout_idx)
+  .. function:: blockchain.outpoint.subscribe(tx_hash, txout_idx, spk_hint=None)
   .. versionadded:: 1.5
 
   *tx_hash*
@@ -589,6 +591,12 @@ as an input (spends it).
 
     The output index, a non-negative integer. (sometimes called prevout_n, in inputs)
 
+  *spk_hint*
+
+    The scriptPubKey (output script) corresponding to the outpoint, as a hexadecimal
+    string. This is optional, and if provided might be used by the server to find
+    the outpoint. The behaviour is undefined if an incorrect value is provided.
+
 **Result**
 
   The status of the TXO, taking the mempool into consideration.
@@ -597,7 +605,8 @@ as an input (spends it).
   * *height*
 
     The integer height of the block the funding transaction was confirmed in.
-    ``0`` if the funding transaction is in the mempool.
+    If the funding transaction is in the mempool; the value is
+    ``0`` if all its inputs are confirmed, and ``-1`` otherwise.
     This key must be present if and only if there exists a funding transaction
     (either in the best chain or in the mempool), regardless of spentness.
 
@@ -610,7 +619,8 @@ as an input (spends it).
   * *spender_height*
 
     The integer height of the block the spending transaction was confirmed in.
-    ``0`` if the spending transaction is in the mempool.
+    If the spending transaction is in the mempool; the value is
+    ``0`` if all its inputs are confirmed, and ``-1`` otherwise.
     This key is present if and only if the *spender_txhash* key is present.
 
 

--- a/docs/protocol-methods.rst
+++ b/docs/protocol-methods.rst
@@ -76,7 +76,7 @@ With *cp_height* 8::
 blockchain.block.headers
 ========================
 
-Return a concatenated chunk of block headers from the main chain.
+Return a chunk of block headers from the main chain.
 
 **Signature**
 
@@ -85,6 +85,7 @@ Return a concatenated chunk of block headers from the main chain.
   .. versionchanged:: 1.4
      *cp_height* parameter added
   .. versionchanged:: 1.4.1
+  .. versionchanged:: 1.5
 
   *start_height*
 
@@ -112,11 +113,19 @@ Return a concatenated chunk of block headers from the main chain.
     the available headers will be returned.  If more headers than
     *max* were requested at most *max* will be returned.
 
+  * *headers*
+
+    An array containing the binary block headers in-order; each header is a
+    hexadecimal string.  AuxPoW data (if present in the original header) is
+    truncated if *cp_height* is nonzero.  Only present in version 1.5 and
+    higher.
+
   * *hex*
 
     The binary block headers concatenated together in-order as a
     hexadecimal string.  Starting with version 1.4.1, AuxPoW data (if present
-    in the original header) is truncated if *cp_height* is nonzero.
+    in the original header) is truncated if *cp_height* is nonzero.  Only
+    present in versions lower than 1.5.
 
   * *max*
 
@@ -149,7 +158,10 @@ See :ref:`here <cp_height example>` for an example of *root* and
 
   {
     "count": 2,
-    "hex": "0100000000000000000000000000000000000000000000000000000000000000000000003ba3edfd7a7b12b27ac72c3e67768f617fc81bc3888a51323a9fb8aa4b1e5e4a29ab5f49ffff001d1dac2b7c010000006fe28c0ab6f1b372c1a6a246ae63f74f931e8365e15a089c68d6190000000000982051fd1e4ba744bbbe680e1fee14677ba1a3c3540bf7b1cdb606e857233e0e61bc6649ffff001d01e36299"
+    "headers":
+    [
+      "0100000000000000000000000000000000000000000000000000000000000000000000003ba3edfd7a7b12b27ac72c3e67768f617fc81bc3888a51323a9fb8aa4b1e5e4a29ab5f49ffff001d1dac2b7c", "010000006fe28c0ab6f1b372c1a6a246ae63f74f931e8365e15a089c68d6190000000000982051fd1e4ba744bbbe680e1fee14677ba1a3c3540bf7b1cdb606e857233e0e61bc6649ffff001d01e36299"
+    ],
     "max": 2016
   }
 

--- a/docs/protocol-methods.rst
+++ b/docs/protocol-methods.rst
@@ -674,6 +674,41 @@ as an input (spends it).
     .. function:: blockchain.outpoint.subscribe([tx_hash, txout_idx], status)
        :noindex:
 
+**Full JSON-RPC Example**
+
+Here is an example where the client sends a request, gets an immediate response,
+and then at some point later - while the connection is still open -
+receives a notification.
+
+::
+
+  -> {
+    "jsonrpc": "2.0",
+    "id": 4,
+    "method": "blockchain.outpoint.subscribe",
+    "params": ["1872b27abc497492a775fe335abfe368af575733144a7ecd4b249d8fd885b3cf", 1]
+  }
+  <- {
+    "jsonrpc": "2.0",
+    "result": {"height": 1866594},
+    "id": 4
+  }
+
+  # notification after broadcasting tx 4a19a360f71814c566977114c49ccfeb8a7e4719eda26cee27fa504f3f02ca09
+  <- {
+    "jsonrpc": "2.0",
+    "method": "blockchain.outpoint.subscribe",
+    "params": [
+      ["1872b27abc497492a775fe335abfe368af575733144a7ecd4b249d8fd885b3cf", 1],
+      {
+        "height": 1866594,
+        "spender_txhash": "4a19a360f71814c566977114c49ccfeb8a7e4719eda26cee27fa504f3f02ca09",
+        "spender_height": 0
+      }
+    ]
+  }
+
+
 blockchain.outpoint.unsubscribe
 ===============================
 

--- a/docs/protocol-methods.rst
+++ b/docs/protocol-methods.rst
@@ -667,9 +667,20 @@ as an input (spends it).
 **Notifications**
 
   The client will receive a notification when the `status` of the outpoint changes.
-  The protocol does not guarantee but the client might also receive a notification
-  if the status does not change but there was a reorg.
-  Its signature is
+  That is, any event that changes any field of the `status` dictionary results in a
+  notification. Some examples:
+
+  * a funding/spending tx appearing in the mempool if there was no such tx when the client subbed
+  * funding/spending tx height changing from -1 to 0 as its inputs got mined
+  * funding/spending tx height changing from 0 to a (positive) block height when it gets mined
+  * note that reorgs can change any of the `status` fields and result in notifications
+  * note that mempool replacement (e.g. due to RBF) or mempool eviction (and potentially other
+    mempool quirks) can also change some of the `status` fields and hence result in notifications
+
+  The client MAY receive a notification even if the status did not change
+  (when e.g. there was a reorg changing the blockhash the tx is mined in but not the height).
+
+  The signature of the notification is
 
     .. function:: blockchain.outpoint.subscribe([tx_hash, txout_idx], status)
        :noindex:

--- a/docs/protocol-methods.rst
+++ b/docs/protocol-methods.rst
@@ -85,7 +85,7 @@ Return a chunk of block headers from the main chain.
   .. versionchanged:: 1.4
      *cp_height* parameter added
   .. versionchanged:: 1.4.1
-  .. versionchanged:: 1.5
+  .. versionchanged:: 2.0
 
   *start_height*
 
@@ -117,7 +117,7 @@ Return a chunk of block headers from the main chain.
 
     An array containing the binary block headers in-order; each header is a
     hexadecimal string.  AuxPoW data (if present in the original header) is
-    truncated if *cp_height* is nonzero.  Only present in version 1.5 and
+    truncated if *cp_height* is nonzero.  Only present in version 2.0 and
     higher.
 
   * *hex*
@@ -125,7 +125,7 @@ Return a chunk of block headers from the main chain.
     The binary block headers concatenated together in-order as a
     hexadecimal string.  Starting with version 1.4.1, AuxPoW data (if present
     in the original header) is truncated if *cp_height* is nonzero.  Only
-    present in versions lower than 1.5.
+    present in versions lower than 2.0.
 
   * *max*
 
@@ -174,7 +174,7 @@ be confirmed within a certain number of blocks.
 **Signature**
 
   .. function:: blockchain.estimatefee(number, mode=None)
-  .. versionchanged:: 1.5
+  .. versionchanged:: 2.0
      *mode* argument added
 
   *number*
@@ -327,7 +327,7 @@ and initiate further requests for the missing interval.
   .. function:: blockchain.scripthash.get_history(scripthash, from_height=0, to_height=-1,
                                                   client_statushash=None, client_height=None)
   .. versionadded:: 1.1
-  .. versionchanged:: 1.5
+  .. versionchanged:: 2.0
      significant changes to allow pagination of history
      (added from_height, to_height, client_height, client_statushash arguments)
      (return value changed to dict from list)
@@ -435,7 +435,7 @@ hashes>`.
 
   .. function:: blockchain.scripthash.get_mempool(scripthash)
   .. versionadded:: 1.1
-  .. versionchanged:: 1.5
+  .. versionchanged:: 2.0
      results must be sorted (previously undefined order)
 
   *scripthash*
@@ -592,7 +592,7 @@ as an input (spends it).
 **Signature**
 
   .. function:: blockchain.outpoint.subscribe(tx_hash, txout_idx, spk_hint=None)
-  .. versionadded:: 1.5
+  .. versionadded:: 2.0
 
   *tx_hash*
 
@@ -730,7 +730,7 @@ if its `status` changes.
 **Signature**
 
   .. function:: blockchain.outpoint.unsubscribe(tx_hash, txout_idx)
-  .. versionadded:: 1.5
+  .. versionadded:: 2.0
 
   *tx_hash*
 
@@ -875,7 +875,7 @@ and height.
 **Signature**
 
   .. function:: blockchain.transaction.get_merkle(tx_hash, height=None)
-  .. versionchanged:: 1.5
+  .. versionchanged:: 2.0
      *height* argument made optional (previously mandatory)
 
   *tx_hash*

--- a/docs/protocol-methods.rst
+++ b/docs/protocol-methods.rst
@@ -386,7 +386,7 @@ height, i.e. calculating *client_statushash* without txs in the last e.g. 200 bl
     If the value is lower than requested (original *to_height*), that indicates
     the server truncated the history (usually because it was too long), and the client
     needs to send a new request with a different block interval if it wants the rest.
-    A non-negative integer.
+    A non-negative integer, or ``-1``.
     ``from_height <= to_height`` must hold.
 
   * *history*
@@ -596,6 +596,8 @@ as an input (spends it).
     The scriptPubKey (output script) corresponding to the outpoint, as a hexadecimal
     string. This is optional, and if provided might be used by the server to find
     the outpoint. The behaviour is undefined if an incorrect value is provided.
+    Note that some implementations (such as EPS/BWT) might require this parameter
+    to be able to serve the request.
 
 **Result**
 

--- a/docs/protocol-methods.rst
+++ b/docs/protocol-methods.rst
@@ -671,6 +671,7 @@ as an input (spends it).
   notification. Some examples:
 
   * a funding/spending tx appearing in the mempool if there was no such tx when the client subbed
+    (note: the server MUST save the subscription even if the outpoint does not exist yet)
   * funding/spending tx height changing from -1 to 0 as its inputs got mined
   * funding/spending tx height changing from 0 to a (positive) block height when it gets mined
   * note that reorgs can change any of the `status` fields and result in notifications


### PR DESCRIPTION
This PR describes an updated Electrum Protocol, version 2.0 (formerly named version 1.5).

Some of these ideas have already been discussed and implemented as part of https://github.com/spesmilo/electrumx/pull/80, however this PR includes even more changes, most notably pagination of long histories (taking into consideration ideas from https://github.com/kyuupichan/electrumx/issues/348 and https://github.com/kyuupichan/electrumx/issues/82).

While the changes described in https://github.com/spesmilo/electrumx/pull/80 are already non-trivial and would be useful in themselves, I have realised I would also like to fix the long-standing issue of serving addresses with long histories, and IMO it would be better to only bump the protocol version once (and to minimise the number of db upgrades/times operators have to resync).

This PR is only documentation, I would like feedback before implementing it.

@romanz, @chris-belcher, @shesek, @cculianu, @ecdsa, @kyuupichan 


-----

Compared to the existing Electrum Protocol (1.4.2), the changes are:
- Breaking change for the version negotiation: we now mandate that the `server.version` message must be the first message sent by the client.
    That is, version negotiation must happen before any other messages.
- The status of a scripthash has been re-defined. The new definition is recursive and makes it possible not to redo all hashing for most updates.
- `blockchain.scripthash.get_history` changed significantly to allow pagination of long histories.
- new method: `blockchain.outpoint.subscribe` to subscribe to a transaction outpoint, lookup its spender tx, and get a notification when it gets spent.
- new method: `blockchain.outpoint.unsubscribe` to unsubscribe from a TXO.
- The previously required `height` argument for `blockchain.transaction.get_merkle` is now optional. (related: https://github.com/spesmilo/electrumx/issues/43 )
- Optional `mode` argument added to `blockchain.estimatefee`. (see https://github.com/kyuupichan/electrumx/pull/1001 )
- `blockchain.scripthash.get_mempool` previously did not define an order for mempool transactions. We now mandate a specific ordering.

-----

Re pagination of long histories:
- The definition of the status hash and the get_history methods changed to accommodate serving long histories.
- The existing Electrum Protocol is extremely inefficient for addresses with long histories; to mitigate DOS, e-x refuses to serve the history of an address if it contains more than ~10k transactions (by default).
- Ideally, it should not be more expensive to serve a client that has a single address with 1 million txs than a client that has 10000 addresses each with 100 txs. Distribution of txs over addresses should not matter.
- The main goal is to optimise for well-behaved non-malicious clients. The server can ban/disconnect clients that use too much resources. With this design, I believe, well-behaved clients under typical scenarios should use similar resources at runtime regardless of their tx distribution over addresses.
- As for implementation, I think the server could store in the db the status hash of a scripthash every ~10k transactions.
    - note that if a scripthash has fewer txs than that, it uses no extra disk space
    - to compute the partial status up to any block height, at most 10k hashes would need to be calculated
    - the server could calculate and store these partial statuses when requests come in, so not during block processing
        - only store a status if it is reorg-safe, e.g. at least 200 blocks deep