### PR TITLE
(WIP) Return headers as JSON array instead of concatenated string

### DIFF
--- a/electrumx/server/session.py
+++ b/electrumx/server/session.py
@@ -1258,7 +1258,7 @@ class ElectrumX(SessionBase):
             next_cursor = self.db.header_offset(height + 1)
             header = headers[cursor:next_cursor]
             result['headers'].append(header)
-            cursor += next_cursor
+            cursor = next_cursor
             height += 1
 
         self.bump_cost(cost)

--- a/electrumx/server/session.py
+++ b/electrumx/server/session.py
@@ -1246,13 +1246,13 @@ class ElectrumX(SessionBase):
         max_size = self.MAX_CHUNK_SIZE
         count = min(count, max_size)
         headers, count = await self.db.read_headers(start_height, count)
-        cursor = 0
         result = {'count': count, 'max': max_size, 'headers': []}
         if count and cp_height:
             cost += 1.0
             last_height = start_height + count - 1
             result.update(await self._merkle_proof(cp_height, last_height))
 
+        cursor = 0
         height = 0
         while cursor < len(headers):
             next_cursor = self.db.header_offset(height + 1)

--- a/electrumx/server/session.py
+++ b/electrumx/server/session.py
@@ -1781,7 +1781,7 @@ class AuxPoWElectrumX(ElectrumX):
             return result
 
         # Covered by a checkpoint; truncate AuxPoW data
-        result['header'] = result['header'][:self.coin.TRUNCATED_HEADER_SIZE]
+        result['header'] = self.truncate_auxpow_single(result['header'])
         return result
 
     async def block_headers(self, start_height, count, cp_height=0):
@@ -1810,5 +1810,9 @@ class AuxPoWElectrumX(ElectrumX):
     def truncate_auxpow_headers(self, headers):
         result = []
         for header in headers:
-            result.append(header[:self.coin.TRUNCATED_HEADER_SIZE])
+            result.append(self.truncate_auxpow_single(header))
         return result
+
+    def truncate_auxpow_single(self, header: str):
+        # 2 hex chars per byte
+        return header[:2*self.coin.TRUNCATED_HEADER_SIZE]

--- a/electrumx/server/session.py
+++ b/electrumx/server/session.py
@@ -1781,26 +1781,30 @@ class AuxPoWElectrumX(ElectrumX):
             return result
 
         # Covered by a checkpoint; truncate AuxPoW data
-        result['header'] = self.truncate_auxpow(result['header'], height)
+        result['header'] = result['header'][:self.coin.TRUNCATED_HEADER_SIZE]
         return result
 
     async def block_headers(self, start_height, count, cp_height=0):
-        result = await super().block_headers(start_height, count, cp_height)
-
         # Older protocol versions don't truncate AuxPoW
         if self.protocol_tuple < (1, 4, 1):
-            return result
+            return await super().block_headers(start_height, count, cp_height)
 
         # Not covered by a checkpoint; return full AuxPoW data
         if cp_height == 0:
-            return result
+            return await super().block_headers(start_height, count, cp_height)
+
+        result = await super().block_headers_array(start_height, count, cp_height)
 
         # Covered by a checkpoint; truncate AuxPoW data
-        if self.protocol_tuple >= (1, 5, 0):
-            result['headers'] = self.truncate_auxpow_headers(result['headers'])
-            return
+        result['headers'] = self.truncate_auxpow_headers(result['headers'])
 
-        result['hex'] = self.truncate_auxpow(result['hex'], start_height)
+        # Return headers in array form
+        if self.protocol_tuple >= (1, 5, 0):
+            return result
+
+        # Return headers in concatenated form
+        result['hex'] = ''.join(result['headers'])
+        del result['headers']
         return result
 
     def truncate_auxpow_headers(self, headers):
@@ -1808,16 +1812,3 @@ class AuxPoWElectrumX(ElectrumX):
         for header in headers:
             result.append(header[:self.coin.TRUNCATED_HEADER_SIZE])
         return result
-
-    def truncate_auxpow(self, headers_full_hex, start_height):
-        height = start_height
-        headers_full = util.hex_to_bytes(headers_full_hex)
-        cursor = 0
-        headers = bytearray()
-
-        while cursor < len(headers_full):
-            headers += headers_full[cursor:cursor+self.coin.TRUNCATED_HEADER_SIZE]
-            cursor += self.db.dynamic_header_len(height)
-            height += 1
-
-        return headers.hex()

--- a/electrumx/server/session.py
+++ b/electrumx/server/session.py
@@ -1257,7 +1257,7 @@ class ElectrumX(SessionBase):
         while cursor < len(headers):
             next_cursor = self.db.header_offset(height + 1)
             header = headers[cursor:next_cursor]
-            result['headers'].append(header)
+            result['headers'].append(header.hex())
             cursor = next_cursor
             height += 1
 


### PR DESCRIPTION
This PR makes the `blockchain.block.headers` method return a JSON array of headers instead of a concatenated string, which improves semantic correctness.