### PR TITLE
Slimmer docker image. Also uses PyPI instead of GitHub for the package

### DIFF
--- a/contrib/Dockerfile
+++ b/contrib/Dockerfile
@@ -1,20 +1,31 @@
-# example of Dockerfile that builds release of electrumx-1.13.0
-# ENV variables can be overrided on the `docker run` command
+# example of Dockerfile that installs spesmilo electrumx 1.16.0
+# ENV variables can be overriden on the `docker run` command
 
-FROM ubuntu:20.04
+FROM python:3.9.4-buster AS builder
 
-WORKDIR /
-ADD https://github.com/spesmilo/electrumx/archive/1.15.0.tar.gz /
-RUN tar zxvf *.tar.gz
+WORKDIR /usr/src/app
 
-RUN apt-get update && \
-        apt-get -y install python3.8 python3-pip librocksdb-dev libsnappy-dev libbz2-dev libz-dev liblz4-dev
+# Install the libs needed by rocksdb (including development headers)
+RUN apt-get update \
+    && apt-get -y --no-install-recommends install \
+        librocksdb-dev libsnappy-dev libbz2-dev libz-dev liblz4-dev \
+    && rm -rf /var/lib/apt/lists/*
 
-RUN cd /electrumx* && pip3 install .[rocksdb]
+RUN python -m venv venv \
+    && venv/bin/pip install --no-cache-dir e-x[rapidjson,rocksdb]==1.16.0
+
+
+FROM python:3.9.4-slim-buster
+
+# Install the libs needed by rocksdb (no development headers or statics)
+RUN apt-get update \
+    && apt-get -y --no-install-recommends install \
+        librocksdb5.17 libsnappy1v5 libbz2-1.0 zlib1g liblz4-1 \
+    && rm -rf /var/lib/apt/lists/*
 
 ENV SERVICES="tcp://:50001"
 ENV COIN=Bitcoin
-ENV DB_DIRECTORY=/db
+ENV DB_DIRECTORY=/var/lib/electrumx
 ENV DAEMON_URL="http://username:password@hostname:port/"
 ENV ALLOW_ROOT=true
 ENV DB_ENGINE=rocksdb
@@ -22,13 +33,16 @@ ENV MAX_SEND=10000000
 ENV BANDWIDTH_UNIT_COST=50000
 ENV CACHE_MB=2000
 
-VOLUME /db
+WORKDIR /usr/src/app
+COPY --from=builder /usr/src/app .
+
+VOLUME /var/lib/electrumx
 
 RUN mkdir -p "$DB_DIRECTORY" && ulimit -n 1048576
 
-CMD ["/usr/bin/python3", "/usr/local/bin/electrumx_server"]
+CMD ["/usr/src/app/venv/bin/python", "/usr/src/app/venv/bin/electrumx_server"]
 
 # build it with eg.: `docker build -t electrumx .`
 # run it with eg.:
-# `docker run -d --net=host -v /home/electrumx/db/:/db -e DAEMON_URL="http://youruser:yourpass@localhost:8332" -e REPORT_SERVICES=tcp://example.com:50001 electrumx`
-# for a proper clean shutdown, send TERM signal to the running container eg.: `docker kill --signal="TERM" CONTAINER_ID`
+# `docker run -d --net=host -v /home/electrumx/db/:/var/lib/electrumx -e DAEMON_URL="http://youruser:yourpass@localhost:8332" -e REPORT_SERVICES=tcp://example.com:50001 electrumx`
+# for a clean shutdown, send TERM signal to the running container eg.: `docker kill --signal="TERM" CONTAINER_ID`


### PR DESCRIPTION
Based on the official Python-on-debian images instead of Ubuntu base.

Unfortunately is a little less readable than the existing one due to having two stages: a build stage based on the thick debian buster Python image and a runtime stage based on the slim debian buster Python image.

Takes the final image size down from 485 MB to 165 MB.