### PR TITLE
Namecoin: add more peers

### DIFF
--- a/electrumx/lib/coins.py
+++ b/electrumx/lib/coins.py
@@ -1179,10 +1179,14 @@ class Namecoin(NameIndexMixin, AuxPowMixin, Coin):
     TX_PER_BLOCK = 10
     RPC_PORT = 8336
     PEERS = [
+        '188.167.144.126 s50002',
+        '46.229.238.187 s57002',
+        '82.119.233.36 s50002',
         'electrum-nmc.le-space.de s50002',
         'ex.lug.gs s446',
         'luggscoqbymhvnkp.onion t82',
         'nmc.bitcoins.sk s50002',
+        'nmc2.bitcoins.sk s57002',
         'ulrichard.ch s50006 t50005',
     ]
     BLOCK_PROCESSOR = block_proc.NameIndexBlockProcessor


### PR DESCRIPTION
Includes some IP addresses, because Namecoin is intended to be an alternative to the DNS; thus it would be highly unfortunate if a DNS outage caused a Namecoin outage.