### PR TITLE
Added code for certificate pinning for hardcoded peers.

### DIFF
--- a/electrumx/lib/peer.py
+++ b/electrumx/lib/peer.py
@@ -40,7 +40,8 @@ class Peer:
              'source', 'ip_addr',
              'last_good', 'last_try', 'try_count')
     FEATURES = ('pruning', 'server_version', 'protocol_min', 'protocol_max',
-                'ssl_port', 'tcp_port')
+                'ssl_port', 'tcp_port',
+                'cert_md5', 'cert_sha1', 'cert_sha256', 'cert_blake2b')
     # This should be set by the application
     DEFAULT_PORTS = {}
 
@@ -250,6 +251,22 @@ class Peer:
         return self._port('tcp_port')
 
     @cachedproperty
+    def cert_md5(self):
+        return self._string('cert_md5')
+
+    @cachedproperty
+    def cert_sha1(self):
+        return self._string('cert_sha1')
+
+    @cachedproperty
+    def cert_sha256(self):
+        return self._string('cert_sha256')
+
+    @cachedproperty
+    def cert_blake2b(self):
+        return self._string('cert_blake2b')
+
+    @cachedproperty
     def server_version(self):
         '''Returns the server version as a string if known, otherwise None.'''
         return self._string('server_version')
@@ -328,6 +345,9 @@ class Peer:
                 features['protocol_max'] = features['protocol_min'] = part[1:]
             elif part[0] == 'p':
                 features['pruning'] = part[1:]
+            elif part[0] == 'x':
+                algorithm, digest = part[1:].split('=', 1)
+                ports['cert_' + algorithm] = digest
 
         features.update(ports)
         features['hosts'] = {host: ports}


### PR DESCRIPTION
I'm curious as to anybody's thoughts on the idea of using TLS certificate hashes to verify peer identity.

This is some code I wrote to add to the 'real_name' format so that cert hashes can be provided, and check them. So, a peer name in coins.py can now look like the blow and the peer will be marked bad if its TLS certificate doesn't match the hashes:

`'electrumx.bitcoinsv.io s xsha256=08aa855b19599d84871cc4ce2218dee0f585eefae8fd8fa1899cad27ebe05d7f xblake2b=36b2e8aae9547d38d18de1f2e0f90153efb60f577acfb078ed330ec414e18d24de6c4c03aba0946bd4c3118707dede3443e6e9e68ce91b5cf18d0cac84703339'`

I haven't looked at how features and peers are exchanged between servers at this time. I'm pretty new to the electrum protocol, and can often struggle to write code.