### PR TITLE
Add Membercoin support

### DIFF
--- a/electrumx/lib/coins.py
+++ b/electrumx/lib/coins.py
@@ -4015,3 +4015,24 @@ class Syscoin(AuxPowMixin, Coin):
     RPC_PORT = 8370
     REORG_LIMIT = 2000
     CHUNK_SIZE = 360
+
+    
+class Membercoin(Coin):
+    NAME = "Membercoin"
+    SHORTNAME = "MEM"
+    GENESIS_HASH = ('0000002642735b23a3d2b2c554d4a9fa'
+                    'b1e7fd864ef330c434156abc3fa2fef5')
+    TX_COUNT = 500
+    TX_COUNT_HEIGHT = 500
+    TX_PER_BLOCK = 2
+    NET = "mainnet"
+    XPUB_VERBYTES = bytes.fromhex("0488b21e")
+    XPRV_VERBYTES = bytes.fromhex("0488ade4")
+    RPC_PORT = 8682
+
+    @classmethod
+    def header_hash(cls, header):
+        '''Given a header return the hash.'''
+        from blake3 import blake3
+        return blake3(header).digest()
+      


### PR DESCRIPTION
<!-- Note: Our primary focus is supporting Bitcoin, and contributions in that regard are appreciated the most!
Due to historical reasons, ElectrumX also has support for many altcoins. These will be kept as long as
maintenance burden can be kept *at a minimum*. When adding a new altcoin, (1) add a unit test (see tests/blocks),
and (2) make sure the Travis tests pass. -->