### PR TITLE
setup.py: de-dupe version number, and expose `__version__` in module

### DIFF
--- a/docs/release_process.txt
+++ b/docs/release_process.txt
@@ -3,7 +3,6 @@
 // 2. Update version number, in:
 // - docs/conf.py
 // - electrumx/__init__.py
-// - setup.py
 
 // 3. Tag
 $ git tag -s VERSION -m "VERSION"

--- a/electrumx/__init__.py
+++ b/electrumx/__init__.py
@@ -1,5 +1,6 @@
-version = 'ElectrumX 1.16.0'
-version_short = version.split()[-1]
+__version__ = "1.16.0"
+version = f'ElectrumX {__version__}'
+version_short = __version__
 
 from electrumx.server.controller import Controller
 from electrumx.server.env import Env

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,21 @@
+import os
+import re
+
 import setuptools
-version = '1.16.0'
+
+
+def find_version():
+    tld = os.path.abspath(os.path.dirname(__file__))
+    filename = os.path.join(tld, 'electrumx', '__init__.py')
+    with open(filename) as f:
+        text = f.read()
+    match = re.search(r"^__version__ = \"(.*)\"$", text, re.MULTILINE)
+    if not match:
+        raise RuntimeError('cannot find version')
+    return match.group(1)
+
+
+version = find_version()
 
 with open('requirements.txt') as f:
     requirements = f.read().splitlines()


### PR DESCRIPTION
- avoid hardcoding version number in `setup.py`, instead get it programmatically
- expose `__version__` field in main module, as is standard practice