### PR TITLE
chore: switch from no longer maintained x11_hash to dash_hash

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -27,7 +27,7 @@ unittests_task:
     # hashes and other altcoin-specific stuff
     - pip install tribushashm
     - pip install blake256
-    - pip install x11_hash
+    - pip install dash_hash
     - pip install git+https://github.com/bitcoinplusorg/x13-hash
     - pip install xevan_hash
     - pip install quark_hash

--- a/docs/HOWTO.rst
+++ b/docs/HOWTO.rst
@@ -25,7 +25,7 @@ DB Engine        A database engine package is required; two are
 ================ ========================
 
 Some coins need an additional package, typically for their block hash
-functions. For example, `x11_hash`_ is required for DASH. Scrypt coins
+functions. For example, `dash_hash`_ is required for DASH. Scrypt coins
 require a Python interpreter compiled and/or linked with OpenSSL 1.1.0
 or higher.
 
@@ -444,6 +444,6 @@ You can then set the port as follows and advertise the service externally on the
 .. _`runit`: http://smarden.org/runit/index.html
 .. _`aiohttp`: https://pypi.python.org/pypi/aiohttp
 .. _`pylru`: https://pypi.python.org/pypi/pylru
-.. _`x11_hash`: https://pypi.python.org/pypi/x11_hash
+.. _`dash_hash`: https://pypi.python.org/pypi/dash_hash
 .. _`contrib/raspberrypi3/install_electrumx.sh`: https://github.com/spesmilo/electrumx/blob/master/contrib/raspberrypi3/install_electrumx.sh
 .. _`contrib/raspberrypi3/run_electrumx.sh`: https://github.com/spesmilo/electrumx/blob/master/contrib/raspberrypi3/run_electrumx.sh

--- a/electrumx/lib/coins.py
+++ b/electrumx/lib/coins.py
@@ -1311,8 +1311,8 @@ class Dash(Coin):
     @classmethod
     def header_hash(cls, header):
         '''Given a header return the hash.'''
-        import x11_hash
-        return x11_hash.getPoWHash(header)
+        import dash_hash
+        return dash_hash.getPoWHash(header)
 
 
 class DashTestnet(Dash):
@@ -2402,8 +2402,8 @@ class Axe(Dash):
         Need to download `axe_hash` module
         Source code: https://github.com/AXErunners/axe_hash
         '''
-        import x11_hash
-        return x11_hash.getPoWHash(header)
+        import dash_hash
+        return dash_hash.getPoWHash(header)
 
 
 class AxeTestnet(Axe):
@@ -2544,8 +2544,8 @@ class Pac(Coin):
     @classmethod
     def header_hash(cls, header):
         '''Given a header return the hash.'''
-        import x11_hash
-        return x11_hash.getPoWHash(header)
+        import dash_hash
+        return dash_hash.getPoWHash(header)
 
 
 class PacTestnet(Pac):
@@ -2656,8 +2656,8 @@ class Polis(Coin):
     @classmethod
     def header_hash(cls, header):
         '''Given a header return the hash.'''
-        import x11_hash
-        return x11_hash.getPoWHash(header)
+        import dash_hash
+        return dash_hash.getPoWHash(header)
 
 
 class MNPCoin(Coin):
@@ -3156,8 +3156,8 @@ class Bitsend(Coin):
             import xevan_hash
             return xevan_hash.getPoWHash(header)
         else:
-            import x11_hash
-            return x11_hash.getPoWHash(header)
+            import dash_hash
+            return dash_hash.getPoWHash(header)
 
     @classmethod
     def genesis_block(cls, block):
@@ -3303,8 +3303,8 @@ class Bolivarcoin(Coin):
     @classmethod
     def header_hash(cls, header):
         '''Given a header return the hash.'''
-        import x11_hash
-        return x11_hash.getPoWHash(header)
+        import dash_hash
+        return dash_hash.getPoWHash(header)
 
 
 class Onixcoin(Coin):
@@ -3328,8 +3328,8 @@ class Onixcoin(Coin):
     @classmethod
     def header_hash(cls, header):
         '''Given a header return the hash.'''
-        import x11_hash
-        return x11_hash.getPoWHash(header)
+        import dash_hash
+        return dash_hash.getPoWHash(header)
 
 
 class Electra(Coin):

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setuptools.setup(
         'groestl': ['groestlcoin-hash>=1.0.1'],
         'tribushashm': ['tribushashm>=1.0.5'],
         'xevan-hash': ['xevan-hash'],
-        'x11-hash': ['x11-hash>=1.4'],
+        'dash_hash': ['dash_hash>=1.4'],
         'zny-yespower-0-5': ['zny-yespower-0-5'],
         'bell-yespower': ['bell-yespower'],
         'cpupower': ['cpupower'],


### PR DESCRIPTION
`x11_hash` had no updates since 2015. `dash_hash` is actively maintained (supports Python3.10 for example).