### PR TITLE
Add some working peers for coin Namecoin

### DIFF
--- a/electrumx/lib/coins.py
+++ b/electrumx/lib/coins.py
@@ -1200,14 +1200,19 @@ class Namecoin(NameIndexAuxPoWMixin, Coin):
     TX_PER_BLOCK = 10
     RPC_PORT = 8336
     PEERS = [
-        '188.167.144.126 s50002',
+        '198.50.223.25 s50002',
         '46.229.238.187 s57002',
-        '82.119.233.36 s50002',
+        '198.50.223.27 s50002',
         'electrum-nmc.le-space.de s50002',
-        'ex.lug.gs s446',
+        'electrumx2.nmc.dotbit.zone s50002',
+        'electrumx4.nmc.dotbit.zone s50002',
         'nmc.bitcoins.sk s50002',
         'nmc2.bitcoins.sk s57002',
         'ulrichard.ch s50006 t50005',
+        'h6qrnwxtwiaahsw4qhk2nbutswwb54vnqso6jrxeuk6nwtfbos7jkoqd.onion s50002',
+        'mqhok2edqcxdpklwovquuvvl2q5or4g2o777qwrinydgzfxjbixq76yd.onion s50002',
+        'wirg2tsto7rme7n26lkd3ivbvxmjyy2pktlozwjuep22jcsfsghfqbqd.onion s50002',
+        'quuzpffsddq3aim3gk4oiczzyt5okjjzf4zpe6okzo6qidao6rshynqd.onion s50002',
     ]
     BLOCK_PROCESSOR = block_proc.NameIndexBlockProcessor
     NAME_EXPIRATION = 36_000


### PR DESCRIPTION
No peers were still working so updating with fresh ones. For security and anti sybil reasons not all old peers were removed, just some working ones added.
