### PR TITLE
Remove raw transaction from error message

### DIFF
--- a/electrumx/server/session.py
+++ b/electrumx/server/session.py
@@ -1454,7 +1454,7 @@ class ElectrumX(SessionBase):
             message = error['message']
             self.logger.info(f'error sending transaction: {message}')
             raise RPCError(BAD_REQUEST, 'the transaction was rejected by '
-                           f'network rules.\n\n{message}\n[{raw_tx}]')
+                           f'network rules.\n\n{message}')
         else:
             self.txs_sent += 1
             client_ver = util.protocol_tuple(self.client)


### PR DESCRIPTION
Errors tend to end up in logs, and logs should not contain sensitive data, so it is better to remove the raw tx from the error message.

<!-- Note: Our primary focus is supporting Bitcoin, and contributions in that regard are appreciated the most!
Due to historical reasons, ElectrumX also has support for many altcoins. These will be kept as long as
maintenance burden can be kept *at a minimum*. When adding a new altcoin, (1) add a unit test (see tests/blocks),
and (2) make sure the CI tests pass. -->