### PR TITLE
Increase allowed aiorpcx version to 0.24

### DIFF
--- a/electrumx/server/controller.py
+++ b/electrumx/server/controller.py
@@ -82,9 +82,9 @@ class Controller(ServerBase):
         '''Start the RPC server and wait for the mempool to synchronize.  Then
         start serving external clients.
         '''
-        if not (0, 23, 0) <= aiorpcx_version < (0, 24):
+        if not (0, 23, 0) <= aiorpcx_version < (0, 25):
             raise RuntimeError(
-                f'aiorpcX version {aiorpcx_version!r} does not match required: 0.23.0<=ver<0.24')
+                f'aiorpcX version {aiorpcx_version!r} does not match required: 0.23.0<=ver<0.25')
 
         env = self.env
         min_str, max_str = env.coin.SESSIONCLS.protocol_min_max_strings()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-aiorpcX[ws]>=0.23.0,<0.24
+aiorpcX[ws]>=0.23.0,<0.25
 attrs
 plyvel
 aiohttp>=3.3,<4


### PR DESCRIPTION
Increase the allowed version of [aiorpcx](https://github.com/kyuupichan/aiorpcX) to the new 0.24 version, which uses the new websockets version, so it's possible to get rid of the websockets deprecation warning when starting electrumX.
Changelog of aiorpcX 0.24: [Changelog](https://github.com/kyuupichan/aiorpcX/blob/master/docs/changelog.rst#version-024-16-jan-2024)