### PR TITLE
implements mempool.get_info and clarifies comments of relayfee

### DIFF
--- a/docs/rpc-interface.rst
+++ b/docs/rpc-interface.rst
@@ -98,6 +98,7 @@ A typical result is as follows (with annotated comments)::
           "getinfo": 3,
           "groups": 1,
           "mempool.get_fee_histogram": 3194,
+          "mempool.get_info": 121,
           "server.add_peer": 9,
           "server.banner": 740,
           "server.donation_address": 754,

--- a/src/electrumx/server/session.py
+++ b/src/electrumx/server/session.py
@@ -1396,10 +1396,22 @@ class ElectrumX(SessionBase):
         return banner
 
     async def relayfee(self):
-        '''The minimum fee a low-priority tx must pay in order to be accepted
-        to the daemon's memory pool.'''
+        """The minimum fee required for a transaction to be relayed on by the daemon to the
+        bitcoin network. Doesn't guarantee mempool acceptance."""
         self.bump_cost(1.0)
         return await self.daemon_request('relayfee')
+
+    async def mempool_info(self) -> dict[str, float]:
+        """
+        mempool.get_info, introduced in protocol 1.6.
+        returns: {
+            "mempoolminfee": BTC/kvB,
+            "minrelaytxfee": BTC/kvB,
+            "incrementalrelayfee": BTC/kvB,
+        }
+        """
+        self.bump_cost(1.0)
+        return await self.daemon_request('mempool_info')
 
     async def estimatefee(self, number, mode=None):
         '''The estimated transaction fee per kilobyte to be paid for a
@@ -1661,6 +1673,7 @@ class ElectrumX(SessionBase):
 
         # experimental:
         handlers['blockchain.transaction.broadcast_package'] = self.package_broadcast
+        handlers['mempool.get_info'] = self.mempool_info
 
         self.request_handlers = handlers
 

--- a/src/electrumx/server/session.py
+++ b/src/electrumx/server/session.py
@@ -1648,7 +1648,6 @@ class ElectrumX(SessionBase):
             'blockchain.block.headers': self.block_headers,
             'blockchain.estimatefee': self.estimatefee,
             'blockchain.headers.subscribe': self.headers_subscribe,
-            'blockchain.relayfee': self.relayfee,
             'blockchain.scripthash.get_balance': self.scripthash_get_balance,
             'blockchain.scripthash.get_history': self.scripthash_get_history,
             'blockchain.scripthash.get_mempool': self.scripthash_get_mempool,
@@ -1671,9 +1670,11 @@ class ElectrumX(SessionBase):
         if ptuple >= (1, 4, 2):
             handlers['blockchain.scripthash.unsubscribe'] = self.scripthash_unsubscribe
 
-        # experimental:
-        handlers['blockchain.transaction.broadcast_package'] = self.package_broadcast
-        handlers['mempool.get_info'] = self.mempool_info
+        if ptuple >= (1, 6):
+            handlers['blockchain.transaction.broadcast_package'] = self.package_broadcast
+            handlers['mempool.get_info'] = self.mempool_info
+        else:
+            handlers['blockchain.relayfee'] = self.relayfee  # removed in 1.6
 
         self.request_handlers = handlers
 

--- a/tests/server/test_daemon.py
+++ b/tests/server/test_daemon.py
@@ -256,6 +256,21 @@ async def test_relayfee(daemon):
 
 
 @pytest.mark.asyncio
+async def test_mempool_info(daemon):
+    bitcoin_per_kvb = 0.00002123
+    response = {
+        'mempoolminfee': bitcoin_per_kvb,
+        'minrelaytxfee': bitcoin_per_kvb,
+        'incrementalrelayfee': bitcoin_per_kvb,
+        'other': 'cruft',
+    }
+    daemon.session = ClientSessionGood(('getmempoolinfo', [], response))
+    expected_result = dict(response)
+    del expected_result['other']
+    assert await daemon.mempool_info() == expected_result
+
+
+@pytest.mark.asyncio
 async def test_mempool_hashes(daemon):
     hashes = ['hex_hash1', 'hex_hash2']
     daemon.session = ClientSessionGood(('getrawmempool', [], hashes))


### PR DESCRIPTION
Adds the `mempool.get_info` rpc to fetch mempoolminfee, minrelaytxfee
and incrementalrelayfee from the daemons getmempoolinfo rpc.
Updates the relayfee comments as the fee returned by
`blockchain.relayfee` doesn't guarantee to get into the mempool as
previously stated in the docstrings.

Part of https://github.com/spesmilo/electrum-protocol/pull/6