### PR TITLE
check daemon version on startup, fix version in banner

### DIFF
--- a/src/electrumx/lib/coins.py
+++ b/src/electrumx/lib/coins.py
@@ -35,7 +35,7 @@ from dataclasses import dataclass
 from decimal import Decimal
 from functools import partial
 from hashlib import sha256
-from typing import Sequence, Tuple
+from typing import Sequence, Tuple, Optional
 
 import electrumx.lib.util as util
 from electrumx.lib.hash import Base58, double_sha256, hash_to_hex_str
@@ -114,6 +114,7 @@ class Coin:
     RPC_PORT: int
     NAME: str
     NET: str
+    MIN_REQUIRED_DAEMON_VERSION: Optional[str] = None
 
     # only used for initial db sync ETAs:
     TX_COUNT_HEIGHT: int  # at a given snapshot of the chain,
@@ -306,6 +307,8 @@ class Bitcoin(BitcoinMixin, Coin):
     TX_COUNT_HEIGHT = 646855
     TX_PER_BLOCK = 2200
     CRASH_CLIENT_VER = (3, 2, 3)
+    # core version 28 introduced 1p1c package relay required for protocol 1.6
+    MIN_REQUIRED_DAEMON_VERSION = "28.0"
     BLACKLIST_URL = 'https://electrum.org/blacklist.json'
     PEERS = [
         'electrum.vom-stausee.de s t',
@@ -382,6 +385,7 @@ class BitcoinTestnet(BitcoinTestnetMixin, Coin):
     NAME = "Bitcoin"
     DESERIALIZER = lib_tx.DeserializerSegWit
     CRASH_CLIENT_VER = (3, 2, 3)
+    MIN_REQUIRED_DAEMON_VERSION = "28.0"
     PEERS = [
         'testnet.hsmiths.com t53011 s53012',
         'testnet.qtornado.com s t',

--- a/src/electrumx/server/controller.py
+++ b/src/electrumx/server/controller.py
@@ -73,7 +73,7 @@ class Notifications:
 
 
 class Controller(ServerBase):
-    '''Manages server initialisation and stutdown.
+    '''Manages server initialisation and shutdown.
 
     Servers are started once the mempool is synced after the block
     processor first catches up with the daemon.
@@ -127,8 +127,11 @@ class Controller(ServerBase):
             )
 
             # Test daemon authentication, and also ensure it has a cached
-            # height.  Do this before entering the task group.
+            # height. Do this before entering the task group.
             await daemon.height()
+
+            # Check if daemon is recent enough
+            await daemon.check_daemon_version()
 
             caught_up_event = Event()
             mempool_event = Event()

--- a/src/electrumx/server/session.py
+++ b/src/electrumx/server/session.py
@@ -1036,6 +1036,7 @@ class ElectrumX(SessionBase):
     '''A TCP server that handles incoming Electrum connections.'''
 
     PROTOCOL_MIN = (1, 4)
+    # consider bumping Coin.MIN_REQUIRED_DAEMON_VERSION too when releasing a new protocol version
     PROTOCOL_MAX = (1, 4, 3)
 
     def __init__(self, *args, **kwargs):


### PR DESCRIPTION
Checks the daemon version on startup against a minimum allowed daemon
version hardcoded in the corresponding `Coin`. This allows ensure that
the connected daemon is running a version that supports all the rpc
calls electrumx requires.