### PR TITLE
session.py: sanitize inputs for tx broadcast RPCs

### DIFF
--- a/src/electrumx/lib/util.py
+++ b/src/electrumx/lib/util.py
@@ -35,7 +35,7 @@ import logging
 import sys
 from collections.abc import Container, Mapping
 from struct import Struct
-from typing import Set
+from typing import Set, Any
 
 import aiorpcx
 
@@ -311,6 +311,19 @@ def protocol_version(client_req, min_tuple, max_tuple):
         result = None
 
     return result, client_min
+
+
+def is_hex_str(text: Any) -> bool:
+    if not isinstance(text, str):
+        return False
+    try:
+        b = bytes.fromhex(text)
+    except Exception:
+        return False
+    # forbid whitespaces in text:
+    if len(text) != 2 * len(b):
+        return False
+    return True
 
 
 struct_le_i = Struct('<i')


### PR DESCRIPTION
```
$ printf '{"id": 1, "method": "server.version", "params": ["testing", "1.4"]}\n{"id": 2, "method": "blockchain.transaction.broadcast", "params": [111]}\n' | nc 127.0.0.1 51001
{"jsonrpc":"2.0","result":["ElectrumX 1.18.0","1.4"],"id":1}
{"jsonrpc":"2.0","error":{"code":-32603,"message":"internal server error"},"id":2
```

server log:
```
INFO:ElectrumX:[2] TCP 127.0.0.1:36954, 0 total
ERROR:ElectrumX:[2] exception handling Request('blockchain.transaction.broadcast', [111])
Traceback (most recent call last):
  File "/home/user/wspace/electrumx/.venv/lib/python3.13/site-packages/aiorpcx/session.py", line 481, in _throttled_request
    result = await self.handle_request(request)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/wspace/electrumx/./src/electrumx/server/session.py", line 1029, in handle_request
    return await coro
           ^^^^^^^^^^
  File "/home/user/wspace/electrumx/./src/electrumx/server/session.py", line 1520, in transaction_broadcast
    self.bump_cost(0.25 + len(raw_tx) / 5000)
                          ~~~^^^^^^^^
TypeError: object of type 'int' has no len()
```