### PR TITLE
session: fix ReplyAndDisconnect. was broken for PaddedRSTransport

### DIFF
--- a/src/electrumx/server/transport.py
+++ b/src/electrumx/server/transport.py
@@ -109,3 +109,10 @@ class PaddedRSTransport(RSTransport):
         super().connection_made(transport)
         coro = self.session.taskgroup.spawn(self._poll_sbuffer())
         self._sbuffer_task = self.loop.create_task(coro)
+
+    async def close(self, *args, **kwargs):
+        '''Close the connection and return when closed.'''
+        # Flush buffer before disconnecting. This makes ReplyAndDisconnect work:
+        self._force_send = True
+        self._maybe_consume_sbuffer()
+        await super().close(*args, **kwargs)


### PR DESCRIPTION
We need to flush the buffer before we disconnect.

~~somewhat ugly :/~~

EDIT: f321x pointed out I overlooked something, so this new implementation is no longer ugly.