### PR TITLE
chore(dockerfile): migrate from RocksDB to LevelDB, update to Python 3.14/Trixie

### DIFF
--- a/contrib/Dockerfile
+++ b/contrib/Dockerfile
@@ -1,26 +1,32 @@
-# example of Dockerfile that installs spesmilo electrumx 1.16.0
-# ENV variables can be overridden on the `docker run` command
+# ElectrumX for Bitcoin with LevelDB
+# Build: docker build -t electrumx .
+#        podman build -t electrumx .
+# Run:   docker run -d --net=host -v ~/electrumx-db:/var/lib/electrumx -e DAEMON_URL="http://youruser:yourpass@localhost:8332" -e REPORT_SERVICES=tcp://example.com:50001 electrumx
+#        podman run -d --net=host -v ~/electrumx-db:/var/lib/electrumx -e DAEMON_URL="http://youruser:yourpass@localhost:8332" -e REPORT_SERVICES=tcp://example.com:50001 electrumx
+# Stop:  docker kill --signal=TERM CONTAINER_ID
+#        podman kill --signal=TERM CONTAINER_ID
 
-FROM python:3.9.16-bullseye AS builder
+FROM python:3.14.3-trixie AS builder
 
 WORKDIR /usr/src/app
 
-# Install the libs needed by rocksdb (including development headers)
+# Install the libs needed by leveldb (including development headers)
 RUN apt-get update \
     && apt-get -y --no-install-recommends install \
-        librocksdb-dev libsnappy-dev libbz2-dev libz-dev liblz4-dev \
+        build-essential git libleveldb-dev libsnappy-dev \
     && rm -rf /var/lib/apt/lists/*
 
 RUN python -m venv venv \
-    && venv/bin/pip install --no-cache-dir e-x[rapidjson,rocksdb]==1.16.0
+    && venv/bin/pip install --no-cache-dir \
+        "e-x[rapidjson,leveldb] @ git+https://github.com/spesmilo/electrumx.git@1.19.0"
 
 
-FROM python:3.9.16-slim-bullseye
+FROM python:3.14.3-slim-trixie
 
-# Install the libs needed by rocksdb (no development headers or statics)
+# Install the libs needed by leveldb (no development headers or statics)
 RUN apt-get update \
     && apt-get -y --no-install-recommends install \
-        librocksdb6.11 libsnappy1v5 libbz2-1.0 zlib1g liblz4-1 \
+        libleveldb1d libsnappy1v5 \
     && rm -rf /var/lib/apt/lists/*
 
 ENV SERVICES="tcp://:50001"
@@ -28,7 +34,7 @@ ENV COIN=Bitcoin
 ENV DB_DIRECTORY=/var/lib/electrumx
 ENV DAEMON_URL="http://username:password@hostname:port/"
 ENV ALLOW_ROOT=true
-ENV DB_ENGINE=rocksdb
+ENV DB_ENGINE=leveldb
 ENV MAX_SEND=10000000
 ENV BANDWIDTH_UNIT_COST=50000
 ENV CACHE_MB=2000
@@ -38,11 +44,6 @@ COPY --from=builder /usr/src/app .
 
 VOLUME /var/lib/electrumx
 
-RUN mkdir -p "$DB_DIRECTORY" && ulimit -n 1048576
+RUN mkdir -p "$DB_DIRECTORY"
 
 CMD ["/usr/src/app/venv/bin/python", "/usr/src/app/venv/bin/electrumx_server"]
-
-# build it with eg.: `docker build -t electrumx .`
-# run it with eg.:
-# `docker run -d --net=host -v /home/electrumx/db/:/var/lib/electrumx -e DAEMON_URL="http://youruser:yourpass@localhost:8332" -e REPORT_SERVICES=tcp://example.com:50001 electrumx`
-# for a clean shutdown, send TERM signal to the running container eg.: `docker kill --signal="TERM" CONTAINER_ID`

--- a/contrib/Dockerfile
+++ b/contrib/Dockerfile
@@ -13,21 +13,18 @@ WORKDIR /usr/src/app
 # Install the libs needed by leveldb (including development headers)
 RUN apt-get update \
     && apt-get -y --no-install-recommends install \
-        build-essential git libleveldb-dev libsnappy-dev \
+        build-essential git libleveldb-dev \
     && rm -rf /var/lib/apt/lists/*
 
 RUN python -m venv venv \
     && venv/bin/pip install --no-cache-dir \
-        "e-x[rapidjson,leveldb] @ git+https://github.com/spesmilo/electrumx.git@1.19.0"
+        "e-x @ git+https://github.com/spesmilo/electrumx.git@1.19.0"
 
 
 FROM python:3.14.3-slim-trixie
 
 # Install the libs needed by leveldb (no development headers or statics)
-RUN apt-get update \
-    && apt-get -y --no-install-recommends install \
-        libleveldb1d libsnappy1v5 \
-    && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get -y --no-install-recommends install libleveldb1d && rm -rf /var/lib/apt/lists/*
 
 ENV SERVICES="tcp://:50001"
 ENV COIN=Bitcoin


### PR DESCRIPTION
- **DB engine**: Switch from RocksDB to LevelDB (`DB_ENGINE=leveldb`), replacing
  `librocksdb-dev`/`librocksdb6.11` with `libleveldb-dev`/`libleveldb1d` and
  the corresponding build/runtime deps
- **Version**: Bump from `e-x==1.16.0` to latest `1.19.0` installed directly from the git repo via pip
- **Python**: Upgrade base images from `python:3.9.16-bullseye` to
  `python:3.14.3-trixie`
- **Debian** `bullseye` –> `trixie`
- **Comments**: Rewrite the header comments with clearer build/run/stop examples for both Docker and Podman
- **Cleanup**: Remove the `ulimit -n 1048576` call (not effective in `RUN`
  layers) and move usage instructions to the top of the file
