### PR TITLE
don't get stuck during shutdown waiting for SessionManager to stop

### DIFF
--- a/src/electrumx/server/session.py
+++ b/src/electrumx/server/session.py
@@ -692,16 +692,24 @@ class SessionManager:
                 await group.spawn(self._manage_servers())
         finally:
             # Stop listening on servers, so no new sessions can be created
+            self.logger.info(f'stop listening on servers, so no new sessions can be created')
             await self._stop_servers(self.servers.keys())
-            # Then close sessions
+            # Then close sessions.
+            # note: only best-effort. sessions that are still doing early-handshake are not yet put
+            #       into the sessions dict.
             self.logger.info(f'closing {len(self.sessions):,d} active sessions')
             async with OldTaskGroup() as group:
                 for session in list(self.sessions):
                     await group.spawn(session.close(force_after=1))
             # Finally, wait for servers to be cleaned up and remove servers
             self.logger.info(f"waiting for all server's resources to close")
-            for server in self.servers.values():
-                await server.wait_closed()
+            try:
+                async with timeout_after(3):
+                    async with OldTaskGroup() as group:
+                        for server in self.servers.values():
+                            await group.spawn(server.wait_closed())
+            except TaskTimeout:
+                self.logger.warning('timed out waiting for server resources to close')
             servers_to_remove = list(self.servers.keys())
             self._remove_servers(servers_to_remove)
 
@@ -901,9 +909,24 @@ class SessionManager:
 class RPCSessionWithTaskGroup(RPCSession):
     def __init__(self, *args, manager_taskgroup: OldTaskGroup, **kwargs):
         RPCSession.__init__(self, *args, **kwargs)
+        self._manager_taskgroup = manager_taskgroup
         self.taskgroup = OldTaskGroup()
         asyncio.get_event_loop().create_task(
-            manager_taskgroup.spawn(self.main_loop()))
+            self._start_main_loop())
+
+    async def _start_main_loop(self) -> None:
+        if self._manager_taskgroup.joined:  # this can happen during shutdown
+            self.logger.warning(
+                f"manager_taskgroup already terminated. closing session during its init.")
+            await self.close(force_after=1.0)
+            return
+        try:
+            await self._manager_taskgroup.spawn(self.main_loop())
+        except RuntimeError:
+            if self._manager_taskgroup.joined:
+                pass  # race: task group terminated just after we checked it before spawning
+            else:
+                raise
 
     async def main_loop(self):
         """Manages taskgroup tied to this session.


### PR DESCRIPTION
during shutdown, a busy server could get stuck waiting forever on this log line:
```
INFO:SessionManager:waiting for all server's resources to close
```
This happens if a new client connects *just before* we stop listening for new connections during shutdown. As such a client would not yet get put into the sessions dict of active sessions, and hence we would not close that session, and then we would wait forever on `server.wait_closed()`.

note:
- the `timeout_after(3)` change should be sufficient to fix the bug described
- the `_start_main_loop` change is to fix the logged `Task exception was never retrieved` errors

see log:
```
2026-03-18T17:46:31.449692906Z INFO:ElectrumX:[36] SSL xx.xx.xx.xx:48303, 33 total
2026-03-18T17:46:42.532045642Z WARNING:Controller:received SIGTERM signal, initiating shutdown
2026-03-18T17:46:42.532074094Z INFO:Controller:shutting down
2026-03-18T17:46:42.533451153Z INFO:Prefetcher:cancelled; prefetcher stopping
2026-03-18T17:46:42.534319153Z INFO:BlockProcessor:flushing to DB for a clean shutdown...
2026-03-18T17:46:42.804120065Z INFO:ElectrumX:[8] disconnected.  Sent 1,969,736 bytes in 12 messages
2026-03-18T17:46:43.081894786Z INFO:ElectrumX:[37] SSL xx.xx.xx.xx:37196, 7 total
2026-03-18T17:46:43.114221817Z INFO:ElectrumX:[38] SSL xx.xx.xx.xx:37826, 8 total
2026-03-18T17:46:43.136865456Z INFO:ElectrumX:[39] SSL xx.xx.xx.xx:65376, 9 total
2026-03-18T17:46:43.190371349Z INFO:ElectrumX:[40] SSL xx.xx.xx.xx:33240, 10 total
2026-03-18T17:46:43.190926440Z INFO:ElectrumX:[41] SSL xx.xx.xx.xx:48276, 11 total
2026-03-18T17:46:43.331333593Z INFO:ElectrumX:[42] SSL xx.xx.xx.xx:48422, 12 total
2026-03-18T17:46:43.385320324Z INFO:ElectrumX:[43] SSL xx.xx.xx.xx:48290, 13 total
2026-03-18T17:46:43.544174665Z INFO:ElectrumX:[44] SSL xx.xx.xx.xx:57090, 7 total
2026-03-18T17:46:43.660732815Z INFO:SessionManager:stop listening on servers, so no new sessions can be created
2026-03-18T17:46:43.660772535Z INFO:SessionManager:closing down server for rpc://127.0.0.1:8000
2026-03-18T17:46:43.660779193Z INFO:SessionManager:closing down server for tcp://all_interfaces:51001
2026-03-18T17:46:43.660784024Z INFO:SessionManager:closing down server for ssl://all_interfaces:51002
2026-03-18T17:46:43.660788621Z INFO:SessionManager:closing 1 active sessions
2026-03-18T17:46:43.703167858Z INFO:ElectrumX:[45] SSL xx.xx.xx.xx:59458, 1
2026-03-18T17:46:43.704859567Z Task exception was never retrieved
2026-03-18T17:46:43.704919163Z future: <Task finished name='Task-1441' coro=<TaskGroup.spawn() done, defined at /usr/local/lib/python3.12/site-packages/aiorpcx/curio.py:205> exception=RuntimeError('task group terminated')>
2026-03-18T17:46:43.704928112Z Traceback (most recent call last):
2026-03-18T17:46:43.704932863Z   File "/usr/local/lib/python3.12/site-packages/aiorpcx/curio.py", line 211, in spawn
2026-03-18T17:46:43.704938243Z     self._add_task(task)
2026-03-18T17:46:43.704942688Z   File "/usr/local/lib/python3.12/site-packages/aiorpcx/curio.py", line 157, in _add_task
2026-03-18T17:46:43.704948140Z     raise RuntimeError('task group terminated')
2026-03-18T17:46:43.704953072Z RuntimeError: task group terminated
2026-03-18T17:46:43.705579195Z INFO:ElectrumX:[46] SSL xx.xx.xx.xx:53554, 2 total
2026-03-18T17:46:43.706381696Z Task exception was never retrieved
2026-03-18T17:46:43.706410424Z future: <Task finished name='Task-1449' coro=<TaskGroup.spawn() done, defined at /usr/local/lib/python3.12/site-packages/aiorpcx/curio.py:205> exception=RuntimeError('task group terminated')>
2026-03-18T17:46:43.706419012Z Traceback (most recent call last):
2026-03-18T17:46:43.706423835Z   File "/usr/local/lib/python3.12/site-packages/aiorpcx/curio.py", line 211, in spawn
2026-03-18T17:46:43.706429540Z     self._add_task(task)
2026-03-18T17:46:43.706434988Z   File "/usr/local/lib/python3.12/site-packages/aiorpcx/curio.py", line 157, in _add_task
2026-03-18T17:46:43.706440192Z     raise RuntimeError('task group terminated')
2026-03-18T17:46:43.706444770Z RuntimeError: task group terminated
2026-03-18T17:46:43.881900608Z INFO:ElectrumX:[47] SSL xx.xx.xx.xx:33056, 3 total
2026-03-18T17:46:43.882805255Z Task exception was never retrieved
2026-03-18T17:46:43.882834359Z future: <Task finished name='Task-1467' coro=<TaskGroup.spawn() done, defined at /usr/local/lib/python3.12/site-packages/aiorpcx/curio.py:205> exception=RuntimeError('task group terminated')>
2026-03-18T17:46:43.882868552Z Traceback (most recent call last):
2026-03-18T17:46:43.882873974Z   File "/usr/local/lib/python3.12/site-packages/aiorpcx/curio.py", line 211, in spawn
2026-03-18T17:46:43.882879619Z     self._add_task(task)
2026-03-18T17:46:43.882884083Z   File "/usr/local/lib/python3.12/site-packages/aiorpcx/curio.py", line 157, in _add_task
2026-03-18T17:46:43.882889028Z     raise RuntimeError('task group terminated')
2026-03-18T17:46:43.882893514Z RuntimeError: task group terminated
2026-03-18T17:46:43.979113844Z INFO:ElectrumX:[48] SSL xx.xx.xx.xx:53972, 4 total
2026-03-18T17:46:43.980168590Z Task exception was never retrieved
2026-03-18T17:46:43.980197406Z future: <Task finished name='Task-1474' coro=<TaskGroup.spawn() done, defined at /usr/local/lib/python3.12/site-packages/aiorpcx/curio.py:205> exception=RuntimeError('task group terminated')>
2026-03-18T17:46:43.980208788Z Traceback (most recent call last):
2026-03-18T17:46:43.980214166Z   File "/usr/local/lib/python3.12/site-packages/aiorpcx/curio.py", line 211, in spawn
2026-03-18T17:46:43.980219966Z     self._add_task(task)
2026-03-18T17:46:43.980224382Z   File "/usr/local/lib/python3.12/site-packages/aiorpcx/curio.py", line 157, in _add_task
2026-03-18T17:46:43.980229240Z     raise RuntimeError('task group terminated')
2026-03-18T17:46:43.980233970Z RuntimeError: task group terminated
2026-03-18T17:46:44.005542261Z INFO:SessionManager:waiting for all server's resources to close
```

<!-- Note: Our primary focus is supporting Bitcoin, and contributions in that regard are appreciated the most!
Due to historical reasons, ElectrumX also has support for many altcoins. These will be kept as long as
maintenance burden can be kept *at a minimum*. When adding a new altcoin, (1) add a unit test (see tests/blocks),
and (2) make sure the CI tests pass. -->