### PR TITLE
deps: rm 'attrs', use stdlib dataclasses instead

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,6 @@ license = {'file'="LICENSE"}
 requires-python = ">=3.10"
 dependencies = [
     "aiorpcx[ws]>=0.25.0,<0.26",
-    "attrs",  # TODO try to use stdlib dataclasses instead
     "plyvel",
     "aiohttp>=3.3,<4",
 ]

--- a/src/electrumx/server/db.py
+++ b/src/electrumx/server/db.py
@@ -18,7 +18,6 @@ from dataclasses import dataclass
 from glob import glob
 from typing import Dict, List, Sequence, Tuple, Optional, TYPE_CHECKING
 
-import attr
 from aiorpcx import run_in_thread, sleep
 
 import electrumx.lib.util as util
@@ -44,17 +43,17 @@ class UTXO:
     value: int       # in satoshis
 
 
-@attr.s(slots=True)
+@dataclass(slots=True)
 class FlushData:
-    height = attr.ib()
-    tx_count = attr.ib()
-    headers = attr.ib()
-    block_tx_hashes = attr.ib()  # type: List[bytes]
+    height: int
+    tx_count: int
+    headers: list[bytes]
+    block_tx_hashes: list[bytes]
     # The following are flushed to the UTXO DB if undo_infos is not None
-    undo_infos = attr.ib()  # type: List[Tuple[Sequence[bytes], int]]
-    adds = attr.ib()  # type: Dict[bytes, bytes]  # txid+out_idx -> hashX+tx_num+value_sats
-    deletes = attr.ib()  # type: List[bytes]  # b'h' db keys, and b'u' db keys
-    tip = attr.ib()
+    undo_infos: list[tuple[Sequence[bytes], int]]
+    adds: dict[bytes, bytes]  # txid+out_idx -> hashX+tx_num+value_sats
+    deletes: list[bytes]  # b'h' db keys, and b'u' db keys
+    tip: bytes
 
 
 COMP_TXID_LEN = 4

--- a/src/electrumx/server/mempool.py
+++ b/src/electrumx/server/mempool.py
@@ -12,10 +12,10 @@ import time
 from abc import ABC, abstractmethod
 from asyncio import Lock
 from collections import defaultdict
+from dataclasses import dataclass
 from typing import Sequence, Tuple, TYPE_CHECKING, Type, Dict, Optional, Set
 import math
 
-import attr
 from aiorpcx import run_in_thread, sleep
 
 from electrumx.lib.hash import hash_to_hex_str, hex_str_to_hash
@@ -27,21 +27,21 @@ if TYPE_CHECKING:
     from electrumx.lib.coins import Coin
 
 
-@attr.s(slots=True)
+@dataclass(slots=True)
 class MemPoolTx:
-    prevouts = attr.ib()   # type: Sequence[Tuple[bytes, int]]  # (txid, txout_idx)
+    prevouts: Sequence[tuple[bytes, int]]  # (txid, txout_idx)
     # A pair is a (hashX, value) tuple
-    in_pairs = attr.ib()   # type: Optional[Sequence[Tuple[bytes, int]]]  # (hashX, value_in_sats)
-    out_pairs = attr.ib()  # type: Sequence[Tuple[bytes, int]]  # (hashX, value_in_sats)
-    fee = attr.ib()        # type: int  # in sats
-    size = attr.ib()       # type: int  # in vbytes
+    in_pairs: Optional[Sequence[tuple[bytes, int]]]  # (hashX, value_in_sats)
+    out_pairs: Sequence[tuple[bytes, int]]  # (hashX, value_in_sats)
+    fee: int  # in sats
+    size: int  # in vbytes
 
 
-@attr.s(slots=True)
+@dataclass(slots=True)
 class MemPoolTxSummary:
-    hash = attr.ib()                    # type: bytes
-    fee = attr.ib()                     # type: int  # in sats
-    has_unconfirmed_inputs = attr.ib()  # type: bool
+    hash: bytes
+    fee: int  # in sats
+    has_unconfirmed_inputs: bool
 
 
 class DBSyncError(Exception):

--- a/src/electrumx/server/session.py
+++ b/src/electrumx/server/session.py
@@ -9,6 +9,7 @@
 
 import asyncio
 import codecs
+from dataclasses import dataclass
 import datetime
 import itertools
 import math
@@ -20,7 +21,6 @@ from functools import partial
 from ipaddress import IPv4Address, IPv6Address, IPv4Network, IPv6Network
 from typing import Iterable, Optional, TYPE_CHECKING, Sequence, Union, Any
 
-import attr
 from aiorpcx import (Event, JSONRPCAutoDetect, JSONRPCConnection,
                      ReplyAndDisconnect, Request, RPCError, RPCSession, Service,
                      handler_invocation, serve_rs, serve_ws, sleep,
@@ -104,12 +104,12 @@ def assert_list_or_tuple(value: Any) -> None:
         raise RPCError(BAD_REQUEST, f'{value} should be a list')
 
 
-@attr.s(slots=True)
+@dataclass(slots=True)
 class SessionGroup:
-    name = attr.ib()
-    weight = attr.ib()
-    sessions = attr.ib()
-    retained_cost = attr.ib()
+    name: str
+    weight: float
+    sessions: set['SessionBase']
+    retained_cost: float
 
     def session_cost(self):
         return sum(session.cost for session in self.sessions)
@@ -118,13 +118,13 @@ class SessionGroup:
         return self.retained_cost + self.session_cost()
 
 
-@attr.s(slots=True)
+@dataclass(slots=True)
 class SessionReferences:
     # All attributes are sets but groups is a list
-    sessions = attr.ib()
-    groups = attr.ib()
-    specials = attr.ib()    # Lower-case strings
-    unknown = attr.ib()     # Strings
+    sessions: set['SessionBase']
+    groups: Sequence['SessionGroup']
+    specials: set[str]  # Lower-case strings
+    unknown: set[str]
 
 
 class SessionManager:


### PR DESCRIPTION
begone, vile dependency

but aiohttp still pulls it in :(  until the fabled aiohttp 4.0 release, that is