### PR TITLE
replace unmaintained rocksdb bindings with f321x's fork

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,8 +44,8 @@ jobs:
           pip install pytest-cov
           pip install Sphinx
           # e-x itself
-          # - install both leveldb (default) and rocksdb bindings
-          pip install ".[rocksdb]"
+          # - install both leveldb and rocksdb bindings
+          pip install ".[leveldb,rocksdb]"
           # hashes and other altcoin-specific stuff
           pip install tribushashm
           pip install blake256

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,11 +43,9 @@ jobs:
           pip install pytest-asyncio
           pip install pytest-cov
           pip install Sphinx
-          # hacks for rocksdb
-          pip install 'Cython<3.0'
-          pip install git+https://github.com/jansegre/python-rocksdb.git@314572c02e7204464a5c3e3475c79d57870a9a03
           # e-x itself
-          pip install .
+          # - install both leveldb (default) and rocksdb bindings
+          pip install ".[rocksdb]"
           # hashes and other altcoin-specific stuff
           pip install tribushashm
           pip install blake256

--- a/contrib/Dockerfile
+++ b/contrib/Dockerfile
@@ -31,6 +31,7 @@ ENV COIN=Bitcoin
 ENV DB_DIRECTORY=/var/lib/electrumx
 ENV DAEMON_URL="http://username:password@hostname:port/"
 ENV ALLOW_ROOT=true
+# TODO change DB_ENGINE default to rocksdb after we tag ElectrumX 2.0?
 ENV DB_ENGINE=leveldb
 ENV MAX_SEND=10000000
 ENV BANDWIDTH_UNIT_COST=50000

--- a/docs/HOWTO.rst
+++ b/docs/HOWTO.rst
@@ -62,21 +62,23 @@ Database Engine
 ===============
 
 You can choose from LevelDB and RocksDB to store transaction
-information on disk.  The time taken and DB size is not significantly
-different.  We tried to support LMDB, but its history write performance
+information on disk.  On an SSD, RocksDB performs better than LevelDB.
+We tried to support LMDB, but its history write performance
 was much worse.
 
 You will need to install one of:
 
 + `plyvel <https://plyvel.readthedocs.io/en/latest/installation.html>`_ for LevelDB.
 
-  Included as part of a regular pip installation of ElectrumX.
+  ``apt install libleveldb-dev build-essential``
+
+  ``pip3 install plyvel`` , or use the ``[leveldb]`` extra install option to ElectrumX.
 
 + `rocksdb-ng <https://pypi.org/project/rocksdb-ng>`_ for RocksDB
 
   (Should work with RocksDB versions 8-10)
 
-  ``apt install librocksdb-dev``
+  ``apt install librocksdb-dev build-essential pkg-config``
 
   ``pip3 install rocksdb-ng`` , or use the ``[rocksdb]`` extra install option to ElectrumX.
 

--- a/docs/HOWTO.rst
+++ b/docs/HOWTO.rst
@@ -71,10 +71,17 @@ You will need to install one of:
 + `plyvel <https://plyvel.readthedocs.io/en/latest/installation.html>`_ for LevelDB.
 
   Included as part of a regular pip installation of ElectrumX.
-+ `python-rocksdb <https://pypi.python.org/pypi/python-rocksdb>`_ for RocksDB
 
-  ``pip3 install python-rocksdb`` or use the rocksdb extra install option to ElectrumX.
-+ `pyrocksdb <http://pyrocksdb.readthedocs.io/en/v0.4/installation.html>`_ for an unmaintained version that doesn't work with recent releases of RocksDB
++ `rocksdb-ng <https://pypi.org/project/rocksdb-ng>`_ for RocksDB
+
+  (Should work with RocksDB versions 8-10)
+
+  ``apt install librocksdb-dev``
+
+  ``pip3 install rocksdb-ng`` , or use the ``[rocksdb]`` extra install option to ElectrumX.
+
++ `python-rocksdb <https://pypi.python.org/pypi/python-rocksdb>`_ for an unmaintained version
+  that doesn't work with recent releases of RocksDB (only <7.0)
 
 Running
 =======

--- a/docs/environment.rst
+++ b/docs/environment.rst
@@ -30,6 +30,17 @@ These environment variables are always required:
   relative to the parent process working directory.  This is the
   directory of the `run` script if you use it.
 
+.. envvar:: DB_ENGINE
+
+  Database engine for the UTXO and history database.
+  Choose one of ``leveldb`` or ``rocksdb``.
+  You will need to install the appropriate python package for your engine.
+  In ElectrumX 1.x versions, the default was leveldb.
+  Warning: It is not possible to switch back and forth,
+  the on-disk DB formats are not compatible with each other: you have to resync from genesis.
+  LevelDB was written with HDDs in mind. RocksDB is more modern
+  and on an SSD takes around ~25% less time than LevelDB to sync from genesis.
+
 .. envvar:: DAEMON_URL
 
   A comma-separated list of daemon URLs.  If more than one is provided
@@ -203,13 +214,6 @@ These environment variables are optional:
 
   Must be a :envvar:`NET` from one of the **Coin** classes in
   `lib/coins.py`_.  Defaults to ``mainnet``.
-
-.. envvar:: DB_ENGINE
-
-  Database engine for the UTXO and history database.  The default is
-  ``leveldb``.  The other alternative is ``rocksdb``.  You will need
-  to install the appropriate python package for your engine.  The
-  value is not case sensitive.
 
 .. envvar:: DONATION_ADDRESS
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ license = {'file'="LICENSE"}
 requires-python = ">=3.10"
 dependencies = [
     "aiorpcx[ws]>=0.25.0,<0.26",
-    "plyvel",
+    "plyvel",  # TODO rm from default install before 2.0 release
     "aiohttp>=3.3,<4",
 ]
 classifiers = [
@@ -42,11 +42,16 @@ electrumx_compact_history = "electrumx.cli.electrumx_compact_history:main"
 version = { attr = 'electrumx.__version__' }
 
 [project.optional-dependencies]
-dev = [
-    "objgraph",
+# DB_ENGINE choices. The user MUST install at least one.
+leveldb = [
+    "plyvel",
 ]
 rocksdb = [
     "rocksdb-ng",  # Felix's fork. ref https://github.com/f321x/python-rocksdb
+]
+# misc
+dev = [
+    "objgraph",
 ]
 rapidjson = [
     "python-rapidjson>=0.4.1,<2.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,8 +46,7 @@ dev = [
     "objgraph",
 ]
 rocksdb = [
-    "python-rocksdb>=0.6.9",
-    "Cython<3.0",
+    "rocksdb-ng",  # Felix's fork. ref https://github.com/f321x/python-rocksdb
 ]
 rapidjson = [
     "python-rapidjson>=0.4.1,<2.0",

--- a/src/electrumx/server/env.py
+++ b/src/electrumx/server/env.py
@@ -13,6 +13,8 @@ from ipaddress import IPv4Address, IPv6Address
 from typing import Type
 
 from aiorpcx import Service, ServicePart
+
+import electrumx
 from electrumx.lib.coins import Coin
 from electrumx.lib.env_base import EnvBase
 
@@ -44,6 +46,7 @@ class Env(EnvBase):
         # Core items
 
         self.db_dir = self.required('DB_DIRECTORY')
+        self.db_engine = self.db_engine_enum()
         self.daemon_url = self.required('DAEMON_URL')
         if coin is not None:
             assert issubclass(coin, Coin)
@@ -62,8 +65,6 @@ class Env(EnvBase):
         self.tor_proxy_port = self.integer('TOR_PROXY_PORT', None)
 
         # Misc
-
-        self.db_engine = self.default('DB_ENGINE', 'leveldb')
         self.banner_file = self.default('BANNER_FILE', None)
         self.tor_banner_file = self.default('TOR_BANNER_FILE',
                                             self.banner_file)
@@ -217,3 +218,30 @@ class Env(EnvBase):
             return self.PD_SELF
         else:
             return self.PD_ON
+
+    def db_engine_enum(self) -> str:
+        from electrumx.server.storage import list_db_engine_choices
+        choices = list_db_engine_choices()
+        db_eng = self.default('DB_ENGINE', None)
+
+        if db_eng is None and electrumx.__version__.startswith("1."):  # temporary legacy hack
+            db_eng = "leveldb"
+        if db_eng is None:
+            raise self.Error(
+                f"required envvar DB_ENGINE not set.\n"
+                f"Choose one from: {choices}.\n"
+                f"The corresponding dependencies also need to be installed. See pip extras.\n"
+                f"In ElectrumX 1.x versions, the default was leveldb.\n"
+                f"Warning: It is not possible to switch back and forth, "
+                f"the on-disk DB formats are not compatible with each other: when switching, "
+                f"you have to resync from genesis.\n"
+                f"LevelDB was written with HDDs in mind. RocksDB is more modern and performs better (on an SSD)."
+            )
+
+        db_eng = db_eng.lower()
+        if db_eng in choices:
+            return db_eng
+        else:
+            raise self.Error(
+                f"bad value for envvar DB_ENGINE: {db_eng!r}. Choose one from: {choices}."
+            )

--- a/src/electrumx/server/storage.py
+++ b/src/electrumx/server/storage.py
@@ -9,7 +9,7 @@
 
 import os
 from functools import partial
-from typing import Type
+from typing import Type, Sequence
 
 import electrumx.lib.util as util
 
@@ -21,6 +21,10 @@ def db_class(name) -> Type['Storage']:
             db_class.import_module()
             return db_class
     raise RuntimeError(f'unrecognised DB engine "{name}"')
+
+
+def list_db_engine_choices() -> Sequence[str]:
+    return [db_class.__name__.lower() for db_class in util.subclasses(Storage)]
 
 
 class Storage:
@@ -81,7 +85,11 @@ class LevelDB(Storage):
 
     @classmethod
     def import_module(cls):
-        import plyvel
+        try:
+            import plyvel
+        except ImportError as e:
+            raise Exception(f"{e}. For the leveldb DB-backend, you should install ElectrumX with the [leveldb] pip extra.") from e
+
         cls.module = plyvel
 
     def open(self, name, create):
@@ -124,7 +132,10 @@ class RocksDB(Storage):
 
     @classmethod
     def import_module(cls):
-        import rocksdb
+        try:
+            import rocksdb
+        except ImportError as e:
+            raise Exception(f"{e}. For the rocksdb DB-backend, you should install ElectrumX with the [rocksdb] pip extra.") from e
         cls.module = rocksdb
 
     def open(self, name, create):

--- a/tests/server/test_env.py
+++ b/tests/server/test_env.py
@@ -307,7 +307,18 @@ def test_DONATION_ADDRESS():
 
 
 def test_DB_ENGINE():
-    assert_default('DB_ENGINE', 'db_engine', 'leveldb')
+    setup_base_env()
+
+    e = Env()
+    assert e.db_engine == "leveldb"
+
+    os.environ['DB_ENGINE'] = "rocksdb"
+    e = Env()
+    assert e.db_engine == "rocksdb"
+
+    os.environ['DB_ENGINE'] = "custom-something"
+    with pytest.raises(Env.Error):
+        e = Env()
 
 
 def test_MAX_SEND():


### PR DESCRIPTION
There are basically no maintained python bindings for RocksDB. The most up to date is perhaps NightTsarina/python-rocksdb, but it only supports up to RocksDB <7. Even debian stable(13) packages RocksDB 9 these days. 

[f321x's new rocksdb bindings](https://github.com/f321x/python-rocksdb) are based on [NightTsarina/python-rocksdb  [0]](https://github.com/NightTsarina/python-rocksdb/commit/dad250943c660bcaac12c701fa1062828847f6cc), plus Claude (LLM) adding support to modern Cython, cpython, and RocksDB.

-----

I skimmed the source diff up to the "v2.0.0" tag ([commit](https://github.com/f321x/python-rocksdb/commit/c1959a82427f85e39c132fae0129568895cc3766)),
and I reproduced the "rocksdb-ng==2.0.0" [sdist from PyPI](https://pypi.org/project/rocksdb-ng/2.0.0/#files). [2]

I skimmed the source diff up to the "v2.2.0" tag ([commit](https://github.com/f321x/python-rocksdb/commit/203532dc6c7bf599690bb9435203bd6752db601f)),
and I reproduced the "rocksdb-ng==2.2.0" [sdist from PyPI](https://pypi.org/project/rocksdb-ng/2.2.0/#files). [3]

-----

`[0]`: https://github.com/NightTsarina/python-rocksdb/commit/dad250943c660bcaac12c701fa1062828847f6cc
`[2]`: `d683f9ac2c02f4a3e8be184bd4559b2c5a2f982272f06545a6ae20e2ffe1ac11  dist/rocksdb_ng-2.0.0.tar.gz`
`[3]`: `80b3dd87c1343a8d5a8232715b72198fed6b56605c8bbe020bc2d895ef66f17c  dist/rocksdb_ng-2.2.0.tar.gz`
