### PR TITLE
session: fix regressed _calc_txoutpoint_status

### DIFF
--- a/src/electrumx/lib/tx.py
+++ b/src/electrumx/lib/tx.py
@@ -119,6 +119,9 @@ class TXOSpendStatus:
     spender_txid_rev: Optional[bytes] = None
     spender_height: Optional[int] = None
 
+    def __post_init__(self):
+        assert (self.spender_txid_rev is not None) == (self.spender_height is not None), (self.spender_txid_rev, self.spender_height)
+
 
 class Deserializer:
     '''Deserializes blocks into transactions.

--- a/src/electrumx/server/session.py
+++ b/src/electrumx/server/session.py
@@ -1485,9 +1485,9 @@ class ElectrumX(SessionBase):
         else:  # mempool is still relevant
             mp_status = await self.mempool.spender_for_txo(prev_txid_rev, txout_idx)
             ret = TXOSpendStatus(
-                funder_height=mp_status.funder_height or oc_status.funder_height,
-                spender_txid_rev=mp_status.spender_txid_rev or oc_status.spender_txid_rev,
-                spender_height=mp_status.spender_height or oc_status.spender_height,
+                funder_height=mp_status.funder_height if mp_status.funder_height is not None else oc_status.funder_height,
+                spender_txid_rev=mp_status.spender_txid_rev if mp_status.spender_txid_rev is not None else oc_status.spender_txid_rev,
+                spender_height=mp_status.spender_height if mp_status.spender_height is not None else oc_status.spender_height,
             )
         return ret
 


### PR DESCRIPTION
followup 8ba533c203b3ccb64fddce0407a9e15124575b4c

```
ERROR:ElectrumX:[0] taskgroup died.
Traceback (most recent call last):
  File "/home/user/wspace/electrumx/./src/electrumx/server/session.py", line 994, in main_loop
    async with self.taskgroup as group:
               ^^^^^^^^^^^^^^
  File "/home/user/wspace/electrumx/.venv/lib/python3.13/site-packages/aiorpcx/curio.py", line 304, in __aexit__
    await self.join()
  File "/home/user/wspace/electrumx/./src/electrumx/lib/util.py", line 389, in join
    task.result()
    ~~~~~~~~~~~^^
  File "/home/user/wspace/electrumx/./src/electrumx/server/session.py", line 1255, in notify
    await self._notify_inner(
    ...<3 lines>...
    )
  File "/home/user/wspace/electrumx/./src/electrumx/server/session.py", line 1341, in _notify_inner
    spend_status_dict = self._convert_txospendstatus_to_protocol_dict(spend_status)
  File "/home/user/wspace/electrumx/./src/electrumx/server/session.py", line 1496, in _convert_txospendstatus_to_protocol_dict
    assert spend_status.spender_height is not None
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AssertionError
```

<!-- Note: Our primary focus is supporting Bitcoin, and contributions in that regard are appreciated the most!
Due to historical reasons, ElectrumX also has support for many altcoins. These will be kept as long as
maintenance burden can be kept *at a minimum*. When adding a new altcoin, (1) add a unit test (see tests/blocks),
and (2) make sure the CI tests pass. -->