### PR TITLE
mempool: trigger refresh after db_height changes, don't wait for poll

### DIFF
--- a/src/electrumx/server/block_processor.py
+++ b/src/electrumx/server/block_processor.py
@@ -449,6 +449,7 @@ class BlockProcessor:
         self.tip = self.coin.header_hash_rev(headers[-1])
         self.tip_advanced_event.set()
         self.tip_advanced_event.clear()
+        self.logger.debug(f"new height: {self.height}")
 
     def advance_txs(
             self,

--- a/src/electrumx/server/controller.py
+++ b/src/electrumx/server/controller.py
@@ -148,6 +148,7 @@ class Controller(ServerBase):
                 return db.db_height
             notifications.height = daemon.height
             notifications.db_height = get_db_height
+            notifications.db_height_changed = db.db_flushed_event.wait
             notifications.cached_height = daemon.cached_height
             notifications.mempool_txids_hum = daemon.mempool_txids_hum
             notifications.raw_transactions = daemon.getrawtransactions

--- a/src/electrumx/server/daemon.py
+++ b/src/electrumx/server/daemon.py
@@ -390,7 +390,10 @@ class Daemon:
 
     async def height(self) -> int:
         '''Query the daemon for its current height.'''
+        old_height = self._height
         self._height = await self._send_single('getblockcount')
+        if old_height != self._height:
+            self.logger.debug(f"new height: {self._height}")
         return self._height
 
     def cached_height(self) -> Optional[int]:

--- a/src/electrumx/server/db.py
+++ b/src/electrumx/server/db.py
@@ -11,6 +11,7 @@
 
 from array import array
 import ast
+import asyncio
 import os
 import time
 from bisect import bisect_right
@@ -126,6 +127,7 @@ class DB:
         self.wall_time = 0
         self.first_sync = True
         self.db_version = -1
+        self.db_flushed_event = asyncio.Event()
 
         self.logger.info(f'using {self.env.db_engine} for DB backend')
 
@@ -301,6 +303,9 @@ class DB:
                              f'since last flush: {tx_per_sec_last:,d}')
             self.logger.info(f'sync time: {formatted_time(self.wall_time)}  '
                              f'ETA: {formatted_time(eta)}')
+
+        self.db_flushed_event.set()
+        self.db_flushed_event.clear()
 
     def flush_fs(self, flush_data):
         '''Write headers, tx counts and block tx hashes to the filesystem.

--- a/src/electrumx/server/mempool.py
+++ b/src/electrumx/server/mempool.py
@@ -17,7 +17,7 @@ from dataclasses import dataclass
 from typing import Sequence, Tuple, TYPE_CHECKING, Type, Dict, Optional, Set, Iterable
 import math
 
-from aiorpcx import run_in_thread, sleep
+from aiorpcx import run_in_thread, sleep, ignore_after
 
 from electrumx.lib.hash import hash_to_hex_str, hex_str_to_hash
 from electrumx.lib.tx import SkipTxDeserialize
@@ -74,6 +74,10 @@ class MemPoolAPI(ABC):
     @abstractmethod
     def db_height(self) -> int:
         '''Return the height flushed to the on-disk DB.'''
+
+    @abstractmethod
+    async def db_height_changed(self) -> None:
+        '''Wait until the on-disk DB height changes.'''
 
     @abstractmethod
     async def mempool_txids_hum(self) -> Sequence[str]:
@@ -316,7 +320,9 @@ class MemPool:
                 )
                 touched_hashxs = set()
                 touched_outpoints = set()
-            await sleep(self.refresh_secs)
+            # poll bitcoind's whole mempool every few seconds; or instantly after the DB height changes
+            async with ignore_after(self.refresh_secs):
+                await self.api.db_height_changed()
 
     async def _process_mempool(
             self,

--- a/src/electrumx/server/session.py
+++ b/src/electrumx/server/session.py
@@ -444,6 +444,7 @@ class SessionManager:
         raw = await self.raw_header(height)
         self.hsub_results = {'hex': raw.hex(), 'height': height}
         self.notified_height = height
+        self.logger.debug(f"new notified_height: {self.notified_height}")
 
     def _session_references(self, items: Iterable[str] | Any, special_strings):
         '''Return a SessionReferences object.'''

--- a/tests/server/test_mempool.py
+++ b/tests/server/test_mempool.py
@@ -1,3 +1,4 @@
+import asyncio
 import dataclasses
 import datetime
 import logging
@@ -218,6 +219,9 @@ class API(MemPoolAPI):
 
     def db_height(self):
         return self._db_height
+
+    async def db_height_changed(self) -> None:
+        await asyncio.Event().wait()  # wait forever: fall back to polling
 
     def cached_height(self):
         return self._cached_height


### PR DESCRIPTION
I want to minimise the time when the following does not hold: `daemon.cached_height() == block_processor.height == db.db_height == session_mgr.notified_height`
