### PR TITLE
prefetcher: trigger refresh after daemon height changes, don't wait for poll

### DIFF
--- a/src/electrumx/server/block_processor.py
+++ b/src/electrumx/server/block_processor.py
@@ -13,7 +13,7 @@ import asyncio
 import time
 from typing import Sequence, Tuple, List, Callable, Optional, TYPE_CHECKING, Type, Set
 
-from aiorpcx import run_in_thread, CancelledError
+from aiorpcx import run_in_thread, CancelledError, ignore_after
 
 import electrumx
 from electrumx.server.daemon import DaemonError, Daemon
@@ -73,7 +73,10 @@ class Prefetcher:
                 # Sleep a while if there is nothing to prefetch
                 await self.refill_event.wait()
                 if not await self._prefetch_blocks():
-                    await asyncio.sleep(self.polling_delay)
+                    # The mempool logic and maybe others can independently notice the daemon's height
+                    # changing. If that happens, we should wake up immediately to fetch blocks.
+                    async with ignore_after(self.polling_delay):
+                        await self.daemon.height_changed.wait()
             except DaemonError as e:
                 self.logger.info(f'ignoring daemon error: {e}')
             except asyncio.CancelledError as e:

--- a/src/electrumx/server/daemon.py
+++ b/src/electrumx/server/daemon.py
@@ -73,6 +73,7 @@ class Daemon:
         self.init_retry = init_retry
         self.max_retry = max_retry
         self._height = None
+        self.height_changed = asyncio.Event()
         self.available_rpcs = {}
         self.session = None
 
@@ -394,6 +395,8 @@ class Daemon:
         self._height = await self._send_single('getblockcount')
         if old_height != self._height:
             self.logger.debug(f"new height: {self._height}")
+            self.height_changed.set()
+            self.height_changed.clear()
         return self._height
 
     def cached_height(self) -> Optional[int]:


### PR DESCRIPTION
similar to 34d7111c795b367a893a624b0a29296897fb9af5

I want to minimise the time when the following does not hold:
`daemon.cached_height() == block_processor.height == db.db_height == session_mgr.notified_height`
