### PR TITLE
session: more work on rpc response consistency

### DIFF
--- a/src/electrumx/server/block_processor.py
+++ b/src/electrumx/server/block_processor.py
@@ -204,6 +204,7 @@ class BlockProcessor:
 
         # Caches of unflushed items.
         self.headers = []  # type: list[bytes]
+        self._bhash_to_bheight = dict()  # type: dict[bytes, int]
         self.txids_rev = []  # type: List[bytes]
         self.undo_infos = []  # type: List[Tuple[Sequence[bytes], int]]
 
@@ -374,6 +375,7 @@ class BlockProcessor:
             height=self.height,
             tx_count=self.tx_count,
             headers=self.headers,
+            bhash_to_bheight=self._bhash_to_bheight,
             block_txids_rev=self.txids_rev,
             undo_infos=self.undo_infos,
             adds=self.utxo_cache,
@@ -444,7 +446,7 @@ class BlockProcessor:
             is_unspendable = (is_unspendable_genesis if height >= genesis_activation
                               else is_unspendable_legacy)
             undo_info = self.advance_txs(block.transactions, is_unspendable)
-            self.db.bhash_to_bheight[header_hash] = height
+            self._bhash_to_bheight[header_hash] = height
             if height >= min_height:
                 self.undo_infos.append((undo_info, height))
                 self.db.write_raw_block(block.raw, height)
@@ -543,7 +545,7 @@ class BlockProcessor:
             is_unspendable = (is_unspendable_genesis if self.height >= genesis_activation
                               else is_unspendable_legacy)
             self.backup_txs(block.transactions, is_unspendable)
-            assert self.height == self.db.bhash_to_bheight.pop(header_hash)
+            self._bhash_to_bheight[header_hash] = self.height
             self.height -= 1
             self.db.tx_counts.pop()
 

--- a/src/electrumx/server/block_processor.py
+++ b/src/electrumx/server/block_processor.py
@@ -197,7 +197,7 @@ class BlockProcessor:
         self.touched_outpoints = set()  # type: Set[Tuple[bytes, int]]
         self.reorg_count = 0
         self.height = -1
-        self.tip = None  # type: Optional[bytes]
+        self.tip = None  # type: Optional[bytes]  # block_hash_rev
         self.tip_advanced_event = asyncio.Event()
         self.tx_count = 0
         self._caught_up_event = None

--- a/src/electrumx/server/db.py
+++ b/src/electrumx/server/db.py
@@ -121,7 +121,7 @@ class DB:
         self.fs_tx_count = 0
         self.db_height = -1
         self.db_tx_count = 0
-        self.db_tip = None  # type: Optional[bytes]
+        self.db_tip = None  # type: Optional[bytes]  # block_hash_rev
         self.last_flush = time.time()
         self.last_flush_tx_count = 0
         self.wall_time = 0

--- a/src/electrumx/server/db.py
+++ b/src/electrumx/server/db.py
@@ -54,11 +54,12 @@ class UTXO:
     value: int       # in satoshis
 
 
-@dataclass(slots=True)
+@dataclass(slots=True, kw_only=True)
 class FlushData:
     height: int
     tx_count: int
     headers: list[bytes]
+    bhash_to_bheight: dict[bytes, int]  # block_hash_rev -> block_height
     block_txids_rev: list[bytes]
     # The following are flushed to the UTXO DB if undo_infos is not None
     undo_infos: list[tuple[Sequence[bytes], int]]
@@ -135,6 +136,9 @@ class DB:
         self.merkle = Merkle()
         self.header_mc = MerkleCache(self.merkle, self.fs_block_hashes_rev)
 
+        # note: all on-disk and in-memory dbs are consistent with each other if BlockProcessor.tip == DB.tip.
+        #       (the mempool is out-of-scope here)
+
         # on-disk: raw block headers in chain order
         self.headers_file = util.LogicalFile('meta/headers', 2, 16000000)
         # on-disk: cumulative number of txs at the end of height N
@@ -146,7 +150,7 @@ class DB:
             self.headers_offsets_file = util.LogicalFile(
                 'meta/headers_offsets', 2, 16000000)
 
-        # in-memory: (block_hash_rev -> block_height) map
+        # in-memory: (block_hash_rev -> block_height) full map
         self.bhash_to_bheight = None  # type: Optional[dict[bytes, int]]
 
     async def _read_tx_counts(self) -> None:
@@ -241,7 +245,7 @@ class DB:
                 f"wanted {count} bhashes, only got {len(block_hashes)}")
         for bheight, bhash in enumerate(block_hashes):
             self.bhash_to_bheight[bhash] = bheight
-        # note: for new blocks, the block_processor will keep the map up-to-date
+        assert len(self.bhash_to_bheight) == self.db_height + 1
 
     def get_blockheight_from_blockhash(self, block_hash_hum: str) -> Optional[int]:
         bhash_rev = hex_str_to_hash(block_hash_hum)
@@ -254,6 +258,7 @@ class DB:
         assert flush_data.height == self.fs_height == self.db_height
         assert flush_data.tip == self.db_tip
         assert not flush_data.headers
+        assert not flush_data.bhash_to_bheight
         assert not flush_data.block_txids_rev
         assert not flush_data.adds
         assert not flush_data.deletes
@@ -270,6 +275,7 @@ class DB:
         '''Flush out cached state.  History is always flushed; UTXOs are
         flushed if flush_utxos.'''
         if flush_data.height == self.db_height:
+            assert flush_data.tip == self.db_tip, f"block_hash mismatch at {flush_data.height}"
             self.assert_flushed(flush_data)
             return
 
@@ -323,6 +329,7 @@ class DB:
         prior_tx_count = (self.tx_counts[self.fs_height]
                           if self.fs_height >= 0 else 0)
         assert len(flush_data.block_txids_rev) == len(flush_data.headers)
+        assert len(flush_data.bhash_to_bheight) == len(flush_data.headers)
         assert flush_data.height == self.fs_height + len(flush_data.headers)
         assert flush_data.tx_count == (self.tx_counts[-1] if self.tx_counts
                                        else 0)
@@ -339,6 +346,9 @@ class DB:
         self.headers_file.write(offset, b''.join(flush_data.headers))
         self.fs_update_header_offsets(offset_start=offset, height_start=height_start, headers=flush_data.headers)
         flush_data.headers.clear()
+        self.bhash_to_bheight.update(flush_data.bhash_to_bheight)
+        assert len(self.bhash_to_bheight) == flush_data.height + 1
+        flush_data.bhash_to_bheight.clear()
 
         offset = height_start * self.tx_counts.itemsize
         self.tx_counts_file.write(offset,
@@ -414,13 +424,14 @@ class DB:
         assert not flush_data.headers
         assert not flush_data.block_txids_rev
         assert flush_data.height < self.db_height
+        assert len(flush_data.bhash_to_bheight) == (self.db_height - flush_data.height)
         self.history.assert_flushed()
 
         start_time = time.time()
         tx_delta = flush_data.tx_count - self.last_flush_tx_count
 
         # 1. (fake-)Flush to file system: this just updates pointers
-        self._backup_fs(flush_data.height, flush_data.tx_count)
+        self._backup_fs(flush_data)
 
         # Crucially, we flush utxo_db and hist_db in the reverse order compared to when advancing,
         #   to maintain the invariant that hist_db_tx_count >= utxo_db_tx_count even if we crash.
@@ -467,12 +478,18 @@ class DB:
         return self.dynamic_header_offset(height + 1)\
                - self.dynamic_header_offset(height)
 
-    def _backup_fs(self, height: int, tx_count: int) -> None:
+    def _backup_fs(self, flush_data: FlushData) -> None:
         '''Back up during a reorg.  This just updates our pointers.'''
-        self.fs_height = height
-        self.fs_tx_count = tx_count
+        self.fs_height = flush_data.height
+        self.fs_tx_count = flush_data.tx_count
+
+        for bhash, bheight in flush_data.bhash_to_bheight.items():
+            assert bheight == self.bhash_to_bheight.pop(bhash)
+        flush_data.bhash_to_bheight.clear()
+        assert len(self.bhash_to_bheight) == flush_data.height + 1
+
         # Truncate header_mc: header count is 1 more than the height.
-        self.header_mc.truncate(height + 1)
+        self.header_mc.truncate(flush_data.height + 1)
 
     async def raw_header(self, height: int) -> bytes:
         '''Return the binary header at the given height.'''

--- a/src/electrumx/server/mempool.py
+++ b/src/electrumx/server/mempool.py
@@ -337,7 +337,7 @@ class MemPool:
         hashXs = self.hashXs
         txo_to_spender = self.txo_to_spender
 
-        if mempool_height != self.api.db_height():
+        if mempool_height != self.api.db_height():  # FIXME should compare blockhash
             raise DBSyncError
 
         # First handle txs that have disappeared

--- a/src/electrumx/server/session.py
+++ b/src/electrumx/server/session.py
@@ -25,6 +25,7 @@ from typing import Iterable, Optional, TYPE_CHECKING, Sequence, Union, Any, Tupl
 from typing import Callable
 import random
 import inspect
+import logging
 
 import aiorpcx
 from aiorpcx import (Event, JSONRPCAutoDetect, JSONRPCConnection,
@@ -160,10 +161,14 @@ def retry_on_chain_sync_error(func=None, *, check_chaintip: bool):
     @functools.wraps(func)
     async def handle_chain_sync_error(self: 'ElectrumX', *args, **kw_args):
         session_mgr = self.session_mgr
-        sleeps = [0, 0.5, 2.5, 5, 10]
+        # note: the last sleep is ~infinite.  A timeout from env.request_timeout will trigger instead.
+        sleeps = [0, 0.5, 2.5, 5, 10, 10**6]  # seconds
+        t0 = time.monotonic()
         for attempt, sleep_time in enumerate(sleeps):
             if sleep_time != 0:
-                # A previous attempt failed. Sleep a bit before retrying. If the height changes, try again right away.
+                # A previous attempt failed. Sleep until the height changes.
+                # (This is a bit racy: we might miss the height changing if it changes before we start
+                #  awaiting the event. So we cap the sleep to sleep_time, and then retry anyway.)
                 async with ignore_after(sleep_time):
                     await session_mgr.notified_height_changed.wait()
             chaintip1 = chaintip2 = None
@@ -180,13 +185,32 @@ def retry_on_chain_sync_error(func=None, *, check_chaintip: bool):
                     raise ChainSyncError(message="chaintip moved while processing request")
             except ChainSyncError as e:
                 self.bump_cost(0.1)  # paranoia: maybe client can force ChainSyncError due to logic bug
-                self.logger.debug(f"got {e!r} while processing request: {func}. retrying ({attempt=}).")
+                time_elapsed = time.monotonic() - t0
+                if time_elapsed > 10.0:
+                    self.logger.debug(
+                        f"got {e!r} while processing request: {func}. retrying ({attempt=}). "
+                        f"time taken: {time_elapsed:.4f} sec")
                 continue  # try again
             assert chaintip1 == chaintip2
+            # success!  sending response now.
+            if attempt != 0:
+                time_elapsed = time.monotonic() - t0
+                self.logger.log(
+                    logging.INFO if time_elapsed > 5.0 else logging.DEBUG,
+                    f"responding to request after ChainSyncError, ({attempt=}): "
+                    f"{func}. time taken: {time_elapsed:.4f} sec")
             return res
+        # exhausted all attempts.  sending error.
+        # note: we should only get here if notified_height_changed at least once while processing the request,
+        #       and we got a ChainSyncError both when trying before and when trying after that.
+        #       That likely means the chaintip moved at least twice.
+        time_elapsed = time.monotonic() - t0
+        self.logger.info(
+            f"sending RPCError to client after exhausting all attempts for ChainSyncError. "
+            f"{func}. time taken: {time_elapsed:.4f} sec")
         raise RPCError(
             BAD_REQUEST,
-            "chaintip moved too many times (or DB not in sync with daemon) while processing request")
+            "chaintip moved too many times, or DB not in sync with daemon, while processing request")
     return handle_chain_sync_error
 
 

--- a/src/electrumx/server/session.py
+++ b/src/electrumx/server/session.py
@@ -167,13 +167,16 @@ def retry_on_chain_sync_error(func=None, *, check_chaintip: bool):
                 async with ignore_after(sleep_time):
                     await session_mgr.notified_height_changed.wait()
             chaintip1 = chaintip2 = None
+            reorgcnt1 = reorgcnt2 = None
             try:
                 if check_chaintip:
                     chaintip1 = session_mgr.get_block_ref_for_chaintip()
+                    reorgcnt1 = session_mgr._reorg_count
                 res = await func(self, *args, **kw_args)
                 if check_chaintip:
                     chaintip2 = session_mgr.get_block_ref_for_chaintip()
-                if chaintip1 != chaintip2:
+                    reorgcnt2 = session_mgr._reorg_count
+                if not (chaintip1 == chaintip2 and reorgcnt1 == reorgcnt2):
                     raise ChainSyncError(message="chaintip moved while processing request")
             except ChainSyncError as e:
                 self.bump_cost(0.1)  # paranoia: maybe client can force ChainSyncError due to logic bug
@@ -262,6 +265,7 @@ class SessionManager:
         ] = LRUCache(maxsize=1000)
         self.oc_txo_status_cache = LRUCache(maxsize=1000)  # type: LRUCache[tuple[bytes, int], TXOSpendStatus]
         self.notified_height = None  # type: int | None
+        self.notified_tip = None  # type: bytes | None  # block_hash_rev
         self.notified_height_changed = asyncio.Event()
         self.hsub_results = None  # type: dict[str, Any] | None
         self._task_group = OldTaskGroup()
@@ -516,9 +520,10 @@ class SessionManager:
         '''
         # Paranoia: a reorg could race and leave db_height lower
         height = min(height, self.db.db_height)
-        raw = await self.raw_header(height)
-        self.hsub_results = {'hex': raw.hex(), 'height': height}
+        raw_header = await self.raw_header(height)
+        self.hsub_results = {'hex': raw_header.hex(), 'height': height}
         self.notified_height = height
+        self.notified_tip = self.env.coin.header_hash_rev(raw_header)
         self.notified_height_changed.set()
         self.notified_height_changed.clear()
         self.logger.debug(f"new notified_height: {self.notified_height}")
@@ -864,22 +869,29 @@ class SessionManager:
         """Returns a BlockRef for the current chaintip of the DB.
         Raises ChainSyncError if the DB height is not up-to-date with the daemon height.
         """
-        daemon_height = self.daemon.cached_height()
+        # daemon_height = self.daemon.cached_height()
         bp_height = self.bp.height
+        bp_tip = self.bp.tip
         db_height = self.db.db_height
+        db_tip = self.db.db_tip
         notif_height = self.notified_height
-        # typical propagation: daemon_height -> bp_height -> db_height -> notified_height
-        # note: no need to compare tip hashes, heights are sufficient. A reorg would necessarily bump the height.
-        #       Well, except if multiple daemons are configured via DAEMON_URL, and they are on different sides
-        #       of a chainsplit, and we just switched between the daemons...
-        if not (daemon_height == bp_height == db_height == notif_height):
+        notif_tip = self.notified_tip
+        # example propagation: daemon_height --(10s)-> bp_height --(0.1s)-> db_height --(1s)-> notified_height
+        # note: we only care about internal consistency: we allow daemon_height to differ. This also
+        #       significantly reduces the size of the critical time window.
+        #       We try to give the illusion of a consistent monolithic information-source to the client.
+        #       Most protocol method handlers only use e-x's db and mempool to resolve requests,
+        #       the few that also query bitcoind need to implement their own logic to make sure
+        #       the state they present is consistent with e-x's current db state.
+        if not (bp_height == db_height == notif_height):
+            raise ChainSyncError(message="DB is lagging behind daemon")
+        if not (bp_tip == db_tip == notif_tip):
             raise ChainSyncError(message="DB is lagging behind daemon")
         assert db_height >= 0
-        tip_hash = self.db.db_tip
-        assert tip_hash is not None
+        assert db_tip is not None
         return BlockRef(
             height=db_height,
-            hash_rev=tip_hash,
+            hash_rev=db_tip,
         )
 
     async def _merkle_branch(
@@ -1596,6 +1608,9 @@ class ElectrumX(SessionBase):
         funder_bhash = funder_item.get("blockhash")
         funder_bheight = None  # type: Optional[int]
         if funder_bhash is not None:
+            # If the daemon's height is higher than our db.db_height, or the daemon *just* reorged,
+            # the db might fail to map this block_hash to a height: that's good for internal consistency.
+            # If our db has not caught up to a change yet, that change should be hidden from clients.
             funder_bheight = self.db.get_blockheight_from_blockhash(funder_bhash)
         if funder_bheight is None:  # if in mempool, will defer to mempool.spender_for_txo
             return TXOSpendStatus(funder_height=None)  # utxo never existed (in chain)

--- a/src/electrumx/server/session.py
+++ b/src/electrumx/server/session.py
@@ -1732,6 +1732,7 @@ class ElectrumX(SessionBase):
         self.bump_cost(1.0 + len(utxos) / 50)
         return {'confirmed': confirmed, 'unconfirmed': unconfirmed}
 
+    @retry_on_chain_sync_error(check_chaintip=True)
     async def phandle_scripthash_get_balance(self, scripthash: str | Any) -> dict[str, Any]:
         '''Return the confirmed and unconfirmed balance of a scripthash.'''
         hashX = scripthash_to_hashX(scripthash)
@@ -1761,21 +1762,25 @@ class ElectrumX(SessionBase):
         #       if we *also* get a cache-miss (but the cache is only cleared when notified_height is updated).
         return conf + unconf
 
+    @retry_on_chain_sync_error(check_chaintip=True)
     async def phandle_scripthash_get_history(self, scripthash: str | Any) -> list[dict[str, Any]]:
         '''Return the confirmed and unconfirmed history of a scripthash.'''
         hashX = scripthash_to_hashX(scripthash)
         return await self.confirmed_and_unconfirmed_history(hashX)
 
+    @retry_on_chain_sync_error(check_chaintip=True)
     async def phandle_scripthash_get_mempool(self, scripthash: str | Any) -> list[dict[str, Any]]:
         '''Return the mempool transactions touching a scripthash.'''
         hashX = scripthash_to_hashX(scripthash)
         return await self.unconfirmed_history(hashX)
 
+    @retry_on_chain_sync_error(check_chaintip=True)
     async def phandle_scripthash_listunspent(self, scripthash: str | Any) -> Sequence[dict[str, Any]]:
         '''Return the list of UTXOs of a scripthash.'''
         hashX = scripthash_to_hashX(scripthash)
         return await self.hashX_listunspent(hashX)
 
+    @retry_on_chain_sync_error(check_chaintip=True)
     async def phandle_scripthash_subscribe(self, scripthash: str | Any) -> Optional[str]:
         '''Subscribe to a script hash.
 
@@ -1824,9 +1829,10 @@ class ElectrumX(SessionBase):
         d["chaintip"] = self.session_mgr.get_block_ref_for_chaintip().to_protocol_json()
         return d
 
-    def phandle_scriptpubkey_subscribe(self, spk: str) -> collections.abc.Awaitable[Optional[str]]:
+    @retry_on_chain_sync_error(check_chaintip=True)
+    async def phandle_scriptpubkey_subscribe(self, spk: str) -> Optional[str]:
         scripthash = spk_to_scripthash(spk)
-        return self.phandle_scripthash_subscribe(scripthash)
+        return await self.phandle_scripthash_subscribe(scripthash)
 
     def phandle_scriptpubkey_unsubscribe(self, spk: str) -> collections.abc.Awaitable[bool]:
         scripthash = spk_to_scripthash(spk)


### PR DESCRIPTION
continues work on `@retry_on_chain_sync_error`, from https://github.com/spesmilo/electrumx/pull/362 :

- allow daemon_height to differ, but otherwise make sure all internal state is consistent
- compare block hashes and add explicit checks for reorgs, don't just compare heights
- also use decorator for older protocol versions:
    - atm no client is using 1.7 but I would want issues to surface if they exist
    - the extra consistency guarantees shouldn't hurt
- add some logging