### PR TITLE
perf: multi-threading experiments (`--disable-gil`?)

### DIFF
--- a/src/electrumx/lib/server_base.py
+++ b/src/electrumx/lib/server_base.py
@@ -52,8 +52,6 @@ class ServerBase:
         self.logger = class_logger(__name__, self.__class__.__name__)
         version_str = ' '.join(sys.version.splitlines())
         self.logger.info(f'Python version: {version_str}')
-        gil_enabled = sys._is_gil_enabled() if hasattr(sys, "_is_gil_enabled") else "unknown"
-        self.logger.info(f'Python GIL enabled: {gil_enabled}')
         self.env = env
         self.start_time = 0
 

--- a/src/electrumx/lib/tx.py
+++ b/src/electrumx/lib/tx.py
@@ -51,6 +51,8 @@ class SkipTxDeserialize(Exception):
 
 
 # note: slotted dataclasses are a bit faster than namedtuples
+# note: frozen dataclasses are much slower than non-frozen
+#       ref https://rednafi.com/python/statically-enforcing-frozen-dataclasses/
 @dataclass(kw_only=True, slots=True)
 class Tx:
     '''Class representing a transaction.'''

--- a/src/electrumx/server/block_processor.py
+++ b/src/electrumx/server/block_processor.py
@@ -524,6 +524,7 @@ class BlockProcessor:
             *,
             height: int,
     ) -> None:
+        """This method must be thread-safe. (runs on bp.pool_executor)"""
 
         tx_num_start = self.db.tx_counts[height - 1] if height > 0 else 0
         is_unspendable = (
@@ -584,6 +585,7 @@ class BlockProcessor:
             height: int,
             add_undo_info: bool,
     ) -> None:
+        """This method must be thread-safe. (runs on bp.pool_executor)"""
 
         tx_num_start = self.db.tx_counts[height - 1] if height > 0 else 0
 
@@ -772,6 +774,8 @@ class BlockProcessor:
         If the UTXO is not in the cache it must be on disk.  We store
         all UTXOs so not finding one indicates a logic error or DB
         corruption.
+
+        This method must be thread-safe. (runs on bp.pool_executor)
         '''
         # Fast track is it being in the cache
         idx_packed = pack_txoutidx(tx_idx)
@@ -803,7 +807,7 @@ class BlockProcessor:
             utxo_value_packed = self.db.utxo_db.get(udb_key)
             if utxo_value_packed:
                 # Remove both entries for this UTXO
-                self.db_deletes.append(hdb_key)
+                self.db_deletes.append(hdb_key)  # FIXME appending to list not guaranteed to be thread-safe
                 self.db_deletes.append(udb_key)
                 return hashX + tx_num_packed + utxo_value_packed
 

--- a/src/electrumx/server/block_processor.py
+++ b/src/electrumx/server/block_processor.py
@@ -451,8 +451,14 @@ class BlockProcessor:
             header_hash = coin.header_hash_rev(block.header)
             is_unspendable = (is_unspendable_genesis if height >= genesis_activation
                               else is_unspendable_legacy)
-            undo_info = self.advance_txs(block.transactions, is_unspendable)
+            tx_num_start = self.tx_count
+            self.txids_rev.append(b''.join(tx.txid_rev for tx in block.transactions))
+            self.advance_txs_process_outputs(block.transactions, is_unspendable=is_unspendable, tx_num_start=tx_num_start)
+            undo_info = self.advance_txs_process_inputs(block.transactions, tx_num_start=tx_num_start)
             self._bhash_to_bheight[header_hash] = height
+            tx_num_end = tx_num_start + len(block.transactions)
+            self.tx_count = tx_num_end
+            self.db.tx_counts.append(tx_num_end)
             if height >= min_height:
                 self.undo_infos.append((undo_info, height))
                 self.db.write_raw_block(block.raw, height)
@@ -465,19 +471,17 @@ class BlockProcessor:
         self.tip_advanced_event.clear()
         self.logger.debug(f"new height: {self.height}")
 
-    def advance_txs(
+    def advance_txs_process_outputs(
             self,
             txs: Sequence[Tx],
+            *,
             is_unspendable: Callable[[bytes], bool],
-    ) -> Sequence[bytes]:
-        self.txids_rev.append(b''.join(tx.txid_rev for tx in txs))
+            tx_num_start: int,
+    ) -> None:
 
         # Use local vars for speed in the loops
-        bl_undo_info = [b"" for _ in txs]  # type: list[bytes]
-        tx_num_start = self.tx_count
         script_hashX = self.coin.hashX_from_script
         put_utxo = self.utxo_cache.__setitem__
-        spend_utxo = self.spend_utxo
         update_touched_hashxs = self.touched_hashxs.update
         add_touched_outpoint = self.touched_outpoints.add
         hashXs_by_tx = [[] for _ in txs]  # type: list[list[bytes]]
@@ -514,6 +518,27 @@ class BlockProcessor:
         ))
 
         # -- barrier. all threads have been joined.
+        for hashXs in hashXs_by_tx:
+            update_touched_hashxs(hashXs)
+        self.db.history.add_unflushed(hashXs_by_tx, tx_num_start, bump_tx_count_next=False)
+
+    def advance_txs_process_inputs(
+            self,
+            txs: Sequence[Tx],
+            *,
+            tx_num_start: int,
+    ) -> Sequence[bytes]:
+
+        # Use local vars for speed in the loops
+        bl_undo_info = [b"" for _ in txs]  # type: list[bytes]
+        spend_utxo = self.spend_utxo
+        update_touched_hashxs = self.touched_hashxs.update
+        add_touched_outpoint = self.touched_outpoints.add
+        hashXs_by_tx = [[] for _ in txs]  # type: list[list[bytes]]
+        _pack_txoutidx = pack_txoutidx
+        _pack_sats = pack_satoshis_val
+        _pack_txnum = pack_txnum
+
         # 2. process tx inputs: spend UTXOs
         # note: we don't care about tx ordering in the block
         def process_txins_for_single_tx(tx_pos: int, tx: Tx) -> None:
@@ -540,15 +565,9 @@ class BlockProcessor:
         ))
 
         # -- barrier. all threads have been joined.
-        # Update touched set for notifications
         for hashXs in hashXs_by_tx:
             update_touched_hashxs(hashXs)
-
-        self.db.history.add_unflushed(hashXs_by_tx, self.tx_count)
-
-        tx_num_end = tx_num_start + len(txs)
-        self.tx_count = tx_num_end
-        self.db.tx_counts.append(tx_num_end)
+        self.db.history.add_unflushed(hashXs_by_tx, tx_num_start, bump_tx_count_next=True)
 
         return bl_undo_info
 

--- a/src/electrumx/server/block_processor.py
+++ b/src/electrumx/server/block_processor.py
@@ -62,7 +62,7 @@ class Prefetcher:
         self.cache_size = 0
         self.min_cache_size = 10 * 1024 * 1024
         # This makes the first fetch be 10 blocks
-        self.ave_size = self.min_cache_size // 10
+        self.ave_size = max(1, self.min_cache_size // 10)
         self.polling_delay = polling_delay_secs
 
     async def main_loop(self, bp_height: int) -> None:
@@ -72,7 +72,8 @@ class Prefetcher:
             try:
                 # Sleep a while if there is nothing to prefetch
                 await self.refill_event.wait()
-                if not await self._prefetch_blocks():
+                daemon_is_ahead = await self._prefetch_blocks()
+                if not daemon_is_ahead:
                     # The mempool logic and maybe others can independently notice the daemon's height
                     # changing. If that happens, we should wake up immediately to fetch blocks.
                     async with ignore_after(self.polling_delay):
@@ -435,6 +436,8 @@ class BlockProcessor:
 
         It is already verified they correctly connect onto our tip.
         '''
+        assert self.state_lock.locked()
+        assert blocks
         min_height = self.db.min_undo_height(self.daemon.cached_height())
         height = self.height
         genesis_activation = self.coin.GENESIS_ACTIVATION
@@ -467,7 +470,7 @@ class BlockProcessor:
         self.txids_rev.append(b''.join(tx.txid_rev for tx in txs))
 
         # Use local vars for speed in the loops
-        undo_info = []
+        undo_info = []  # type: list[bytes]
         tx_num = self.tx_count
         script_hashX = self.coin.hashX_from_script
         put_utxo = self.utxo_cache.__setitem__

--- a/src/electrumx/server/block_processor.py
+++ b/src/electrumx/server/block_processor.py
@@ -467,6 +467,7 @@ class BlockProcessor:
             txs: Sequence[Tx],
             is_unspendable: Callable[[bytes], bool],
     ) -> Sequence[bytes]:
+        # TODO split into two funcs, first fund all outputs, second spend all inputs
         self.txids_rev.append(b''.join(tx.txid_rev for tx in txs))
 
         # Use local vars for speed in the loops
@@ -478,29 +479,17 @@ class BlockProcessor:
         undo_info_append = undo_info.append
         update_touched_hashxs = self.touched_hashxs.update
         add_touched_outpoint = self.touched_outpoints.add
-        hashXs_by_tx = []  # type: list[list[bytes]]
-        append_hashXs = hashXs_by_tx.append
+        hashXs_by_tx = [[] for _ in txs]  # type: list[list[bytes]]
         _pack_txoutidx = pack_txoutidx
         _pack_sats = pack_satoshis_val
         _pack_txnum = pack_txnum
 
-        for tx in txs:
+        # Add the new UTXOs
+        for tx, hashXs in zip(txs, hashXs_by_tx):
             txid_rev = tx.txid_rev
-            hashXs = []  # type: list[bytes]
-            append_hashX = hashXs.append
+            add_hashXs = hashXs.append
             tx_numb = _pack_txnum(tx_num)
 
-            # Spend the inputs
-            for txin in tx.inputs:
-                if txin.is_generation():
-                    continue
-                cache_value = spend_utxo(txin.prev_txid_rev, txin.prev_idx)
-                undo_info_append(cache_value)
-                append_hashX(cache_value[:HASHX_LEN])
-                prevout_tuple = (txin.prev_txid_rev, txin.prev_idx)
-                add_touched_outpoint(prevout_tuple)
-
-            # Add the new UTXOs
             for idx, txout in enumerate(tx.outputs):
                 # Ignore unspendable outputs
                 if is_unspendable(txout.pk_script):
@@ -508,14 +497,28 @@ class BlockProcessor:
 
                 # Get the hashX
                 hashX = script_hashX(txout.pk_script)
-                append_hashX(hashX)
+                add_hashXs(hashX)
                 put_utxo(txid_rev + _pack_txoutidx(idx),
                          hashX + tx_numb + _pack_sats(txout.value))
                 add_touched_outpoint((txid_rev, idx))
-
-            append_hashXs(hashXs)
-            update_touched_hashxs(hashXs)
             tx_num += 1
+
+        # Spend the inputs
+        # A separate for-loop here allows any tx ordering in block.
+        for tx, hashXs in zip(txs, hashXs_by_tx):
+            add_hashXs = hashXs.append
+            for txin in tx.inputs:
+                if txin.is_generation():
+                    continue
+                cache_value = spend_utxo(txin.prev_txid_rev, txin.prev_idx)
+                undo_info_append(cache_value)
+                add_hashXs(cache_value[:HASHX_LEN])
+                prevout_tuple = (txin.prev_txid_rev, txin.prev_idx)
+                add_touched_outpoint(prevout_tuple)
+
+        # Update touched set for notifications
+        for hashXs in hashXs_by_tx:
+            update_touched_hashxs(hashXs)
 
         self.db.history.add_unflushed(hashXs_by_tx, self.tx_count)
 

--- a/src/electrumx/server/block_processor.py
+++ b/src/electrumx/server/block_processor.py
@@ -10,6 +10,7 @@
 
 
 import asyncio
+import concurrent.futures
 from concurrent.futures import ThreadPoolExecutor
 import time
 from typing import Sequence, Tuple, List, Callable, Optional, TYPE_CHECKING, Type, Set
@@ -241,7 +242,7 @@ class BlockProcessor:
         first = self.height + 1
         # blocks = [self.coin.block(raw_block, first + n)
         #           for n, raw_block in enumerate(raw_blocks)]
-        blocks = self.pool_executor.map(self.coin.block, raw_blocks, range(first, first + (len(raw_blocks))))
+        blocks = self.pool_executor1.map(self.coin.block, raw_blocks, range(first, first + (len(raw_blocks))))
         blocks = list(blocks)  # join threads
         headers = [block.header for block in blocks]
         hprevs = [self.coin.header_prevhash_rev(h) for h in headers]
@@ -442,7 +443,6 @@ class BlockProcessor:
         assert self.state_lock.locked()
         assert blocks
         min_height = self.db.min_undo_height(self.daemon.cached_height())
-        genesis_activation = self.coin.GENESIS_ACTIVATION
         coin = self.coin
 
         tx_num = self.tx_count
@@ -456,30 +456,36 @@ class BlockProcessor:
             self.db.tx_counts.append(tx_num)
         self.tx_count = tx_num
 
+        # process tx outputs
+        blk_process_outputs = []  # type: list[concurrent.futures.Future]
         height = self.height
         for block in blocks:
             height += 1
-            tx_num_start = self.db.tx_counts[height-1] if height > 0 else 0
-            is_unspendable = (is_unspendable_genesis if height >= genesis_activation
-                              else is_unspendable_legacy)
-            add_unflushed_hist1 = self.advance_txs_process_outputs(
+            fut = self.pool_executor1.submit(
+                self.advance_txs_process_outputs,
                 block.transactions,
-                tx_num_start=tx_num_start,
-                is_unspendable=is_unspendable,
+                height=height,
             )
-            add_unflushed_hist1()
+            blk_process_outputs.append(fut)
+        for fut in blk_process_outputs:
+            add_unflushed_hist = fut.result()
+            add_unflushed_hist()
 
+        # process tx inputs
+        blk_process_inputs = []  # type: list[concurrent.futures.Future]
         height = self.height
         for block in blocks:
             height += 1
-            tx_num_start = self.db.tx_counts[height - 1] if height > 0 else 0
-            add_unflushed_hist2 = self.advance_txs_process_inputs(
+            fut = self.pool_executor1.submit(
+                self.advance_txs_process_inputs,
                 block.transactions,
-                tx_num_start=tx_num_start,
                 height=height,
                 add_undo_info=height >= min_height,
             )
-            add_unflushed_hist2()
+            blk_process_inputs.append(fut)
+        for fut in blk_process_inputs:
+            add_unflushed_hist = fut.result()
+            add_unflushed_hist()
 
         height = self.height
         for block in blocks:
@@ -499,9 +505,13 @@ class BlockProcessor:
             self,
             txs: Sequence[Tx],
             *,
-            is_unspendable: Callable[[bytes], bool],
-            tx_num_start: int,
+            height: int,
     ) -> Callable[[], None]:
+
+        tx_num_start = self.db.tx_counts[height - 1] if height > 0 else 0
+        is_unspendable = (
+            is_unspendable_genesis if height >= self.coin.GENESIS_ACTIVATION
+            else is_unspendable_legacy)
 
         # Use local vars for speed in the loops
         script_hashX = self.coin.hashX_from_script
@@ -536,7 +546,7 @@ class BlockProcessor:
             for tx_pos, tx in txs_chunk:
                 process_txouts_for_single_tx(tx_pos=tx_pos, tx=tx)
 
-        list(self.pool_executor.map(
+        list(self.pool_executor2.map(
             process_txouts_for_chunk,
             chunks(list(enumerate(txs)), 200),
         ))
@@ -551,10 +561,11 @@ class BlockProcessor:
             self,
             txs: Sequence[Tx],
             *,
-            tx_num_start: int,
             height: int,
             add_undo_info: bool,
     ) -> Callable[[], None]:
+
+        tx_num_start = self.db.tx_counts[height - 1] if height > 0 else 0
 
         # Use local vars for speed in the loops
         bl_undo_info = [b"" for _ in txs]  # type: list[bytes]
@@ -586,7 +597,7 @@ class BlockProcessor:
             for tx_pos, tx in txs_chunk:
                 process_txins_for_single_tx(tx_pos=tx_pos, tx=tx)
 
-        list(self.pool_executor.map(
+        list(self.pool_executor2.map(
             process_txins_for_chunk,
             chunks(list(enumerate(txs)), 200),
         ))
@@ -827,16 +838,24 @@ class BlockProcessor:
         '''
         self._caught_up_event = caught_up_event
         await self._first_open_dbs()
-        with ThreadPoolExecutor() as self.pool_executor:
-            try:
-                async with OldTaskGroup() as group:
-                    await group.spawn(self.prefetcher.main_loop(self.height))
-                    await group.spawn(self._process_prefetched_blocks())
-            # Don't flush for arbitrary exceptions as they might be a cause or consequence of
-            # corrupted data
-            except CancelledError:
-                self.logger.info('flushing to DB for a clean shutdown...')
-                await self.flush(True)
+        # create two threadpools:
+        # - multi-block level work split happens in pool1,
+        # - intra-block (txs) level work split happens in pool2.
+        # A single threadpool is not enough as that could deadlock: there might be no more threads
+        # to start work, and all existing threads might be waiting on new work they just scheduled.
+        # To avoid this, we logically nest the pools: top-level code schedules work onto pool1,
+        # code already running in pool1 schedules work onto pool2.
+        with ThreadPoolExecutor() as self.pool_executor1:
+            with ThreadPoolExecutor() as self.pool_executor2:
+                try:
+                    async with OldTaskGroup() as group:
+                        await group.spawn(self.prefetcher.main_loop(self.height))
+                        await group.spawn(self._process_prefetched_blocks())
+                # Don't flush for arbitrary exceptions as they might be a cause or consequence of
+                # corrupted data
+                except CancelledError:
+                    self.logger.info('flushing to DB for a clean shutdown...')
+                    await self.flush(True)
 
     def force_chain_reorg(self, count: int) -> bool:
         '''Force a reorg of the given number of blocks.

--- a/src/electrumx/server/block_processor.py
+++ b/src/electrumx/server/block_processor.py
@@ -641,6 +641,7 @@ class BlockProcessor:
         The blocks should be in order of decreasing height, starting at.
         self.height.  A flush is performed once the blocks are backed up.
         '''
+        assert self.state_lock.locked()
         self.db.assert_flushed(self.flush_data())
         assert self.height >= len(raw_blocks)
         genesis_activation = self.coin.GENESIS_ACTIVATION
@@ -937,67 +938,13 @@ class NameIndexBlockProcessor(BlockProcessor):
 
 
 class LTORBlockProcessor(BlockProcessor):
-
-    def advance_txs(self, txs, is_unspendable):
-        self.txids_rev.append(b''.join(tx.txid_rev for tx in txs))
-
-        # Use local vars for speed in the loops
-        undo_info = []
-        tx_num = self.tx_count
-        script_hashX = self.coin.hashX_from_script
-        put_utxo = self.utxo_cache.__setitem__
-        spend_utxo = self.spend_utxo
-        undo_info_append = undo_info.append
-        update_touched_hashxs = self.touched_hashxs.update
-        add_touched_outpoint = self.touched_outpoints.add
-        _pack_txoutidx = pack_txoutidx
-        _pack_sats = pack_satoshis_val
-        _pack_txnum = pack_txnum
-
-        hashXs_by_tx = [set() for _ in txs]
-
-        # Add the new UTXOs
-        for tx, hashXs in zip(txs, hashXs_by_tx):
-            txid_rev = tx.txid_rev
-            add_hashXs = hashXs.add
-            tx_numb = _pack_txnum(tx_num)
-
-            for idx, txout in enumerate(tx.outputs):
-                # Ignore unspendable outputs
-                if is_unspendable(txout.pk_script):
-                    continue
-
-                # Get the hashX
-                hashX = script_hashX(txout.pk_script)
-                add_hashXs(hashX)
-                put_utxo(txid_rev + _pack_txoutidx(idx),
-                         hashX + tx_numb + _pack_sats(txout.value))
-                add_touched_outpoint((txid_rev, idx))
-            tx_num += 1
-
-        # Spend the inputs
-        # A separate for-loop here allows any tx ordering in block.
-        for tx, hashXs in zip(txs, hashXs_by_tx):
-            add_hashXs = hashXs.add
-            for txin in tx.inputs:
-                if txin.is_generation():
-                    continue
-                cache_value = spend_utxo(txin.prev_txid_rev, txin.prev_idx)
-                undo_info_append(cache_value)
-                add_hashXs(cache_value[:HASHX_LEN])
-                prevout_tuple = (txin.prev_txid_rev, txin.prev_idx)
-                add_touched_outpoint(prevout_tuple)
-
-        # Update touched set for notifications
-        for hashXs in hashXs_by_tx:
-            update_touched_hashxs(hashXs)
-
-        self.db.history.add_unflushed(hashXs_by_tx, self.tx_count)
-
-        self.tx_count = tx_num
-        self.db.tx_counts.append(tx_num)
-
-        return undo_info
+    # for Lexicographical Transaction ordering in blocks
+    # (as opposed to Topological order as used in Bitcoin)
+    # note: the base class already does not care about tx ordering inside a block
+    #       for the forward (catch-up) direction, as that better parallelizes.
+    #       This subclass is only kept for the reverse (backup) direction, for now.
+    #       We could also parallelize backup_txs in the base class for better perf,
+    #       likely removing the tx ordering assumptions, then we could rm this subclass.
 
     def backup_txs(self, txs, is_unspendable):
         undo_info = self.db.read_undo_info(self.height)

--- a/src/electrumx/server/block_processor.py
+++ b/src/electrumx/server/block_processor.py
@@ -908,10 +908,16 @@ class DecredBlockProcessor(BlockProcessor):
 
 class NameIndexBlockProcessor(BlockProcessor):
 
-    def advance_txs(self, txs, is_unspendable):
-        result = super().advance_txs(txs, is_unspendable)
+    def advance_txs_process_outputs(
+            self,
+            txs: Sequence[Tx],
+            *,
+            height: int,
+    ) -> None:
+        result = super().advance_txs_process_outputs(txs, height=height)
 
-        tx_num = self.tx_count - len(txs)
+        tx_num_start = self.db.tx_counts[height - 1] if height > 0 else 0
+        tx_num = tx_num_start
         script_name_hashX = self.coin.name_hashX_from_script
         update_touched_hashxs = self.touched_hashxs.update
         hashXs_by_tx = []
@@ -932,7 +938,7 @@ class NameIndexBlockProcessor(BlockProcessor):
             update_touched_hashxs(hashXs)
             tx_num += 1
 
-        self.db.history.add_unflushed(hashXs_by_tx, self.tx_count - len(txs))
+        self.db.history.add_unflushed(hashXs_by_tx, tx_num_start)
 
         return result
 

--- a/src/electrumx/server/block_processor.py
+++ b/src/electrumx/server/block_processor.py
@@ -239,8 +239,10 @@ class BlockProcessor:
         if not raw_blocks:
             return
         first = self.height + 1
-        blocks = [self.coin.block(raw_block, first + n)
-                  for n, raw_block in enumerate(raw_blocks)]
+        # blocks = [self.coin.block(raw_block, first + n)
+        #           for n, raw_block in enumerate(raw_blocks)]
+        blocks = self.pool_executor.map(self.coin.block, raw_blocks, range(first, first + (len(raw_blocks))))
+        blocks = list(blocks)  # join threads
         headers = [block.header for block in blocks]
         hprevs = [self.coin.header_prevhash_rev(h) for h in headers]
         chain = [self.tip] + [self.coin.header_hash_rev(h) for h in headers[:-1]]

--- a/src/electrumx/server/block_processor.py
+++ b/src/electrumx/server/block_processor.py
@@ -474,7 +474,7 @@ class BlockProcessor:
 
         # Use local vars for speed in the loops
         bl_undo_info = [b"" for _ in txs]  # type: list[bytes]
-        tx_num = self.tx_count
+        tx_num_start = self.tx_count
         script_hashX = self.coin.hashX_from_script
         put_utxo = self.utxo_cache.__setitem__
         spend_utxo = self.spend_utxo
@@ -486,9 +486,10 @@ class BlockProcessor:
         _pack_txnum = pack_txnum
 
         # 1. process tx outputs: fund UTXOs
-        for tx, hashXs in zip(txs, hashXs_by_tx):
+        for tx_pos, tx in enumerate(txs):
             txid_rev = tx.txid_rev
-            add_hashXs = hashXs.append
+            add_hashXs = hashXs_by_tx[tx_pos].append
+            tx_num = tx_num_start + tx_pos
             tx_numb = _pack_txnum(tx_num)
 
             for idx, txout in enumerate(tx.outputs):
@@ -502,7 +503,6 @@ class BlockProcessor:
                 put_utxo(txid_rev + _pack_txoutidx(idx),
                          hashX + tx_numb + _pack_sats(txout.value))
                 add_touched_outpoint((txid_rev, idx))
-            tx_num += 1
 
         # 2. process tx inputs: spend UTXOs
         # note: we don't care about tx ordering in the block
@@ -535,8 +535,9 @@ class BlockProcessor:
 
         self.db.history.add_unflushed(hashXs_by_tx, self.tx_count)
 
-        self.tx_count = tx_num
-        self.db.tx_counts.append(tx_num)
+        tx_num_end = tx_num_start + len(txs)
+        self.tx_count = tx_num_end
+        self.db.tx_counts.append(tx_num_end)
 
         return bl_undo_info
 

--- a/src/electrumx/server/block_processor.py
+++ b/src/electrumx/server/block_processor.py
@@ -471,12 +471,11 @@ class BlockProcessor:
         self.txids_rev.append(b''.join(tx.txid_rev for tx in txs))
 
         # Use local vars for speed in the loops
-        undo_info = []  # type: list[bytes]
+        bl_undo_info = [b"" for _ in txs]  # type: list[bytes]
         tx_num = self.tx_count
         script_hashX = self.coin.hashX_from_script
         put_utxo = self.utxo_cache.__setitem__
         spend_utxo = self.spend_utxo
-        undo_info_append = undo_info.append
         update_touched_hashxs = self.touched_hashxs.update
         add_touched_outpoint = self.touched_outpoints.add
         hashXs_by_tx = [[] for _ in txs]  # type: list[list[bytes]]
@@ -505,16 +504,19 @@ class BlockProcessor:
 
         # Spend the inputs
         # A separate for-loop here allows any tx ordering in block.
-        for tx, hashXs in zip(txs, hashXs_by_tx):
-            add_hashXs = hashXs.append
+        for tx_pos, tx in enumerate(txs):
+            add_hashXs = hashXs_by_tx[tx_pos].append
+            tx_undo_info = []  # type: list[bytes]
+            tx_undo_info_append = tx_undo_info.append
             for txin in tx.inputs:
                 if txin.is_generation():
                     continue
                 cache_value = spend_utxo(txin.prev_txid_rev, txin.prev_idx)
-                undo_info_append(cache_value)
+                tx_undo_info_append(cache_value)
                 add_hashXs(cache_value[:HASHX_LEN])
                 prevout_tuple = (txin.prev_txid_rev, txin.prev_idx)
                 add_touched_outpoint(prevout_tuple)
+            bl_undo_info[tx_pos] = b"".join(tx_undo_info)
 
         # Update touched set for notifications
         for hashXs in hashXs_by_tx:
@@ -525,7 +527,7 @@ class BlockProcessor:
         self.tx_count = tx_num
         self.db.tx_counts.append(tx_num)
 
-        return undo_info
+        return bl_undo_info
 
     def backup_blocks(self, raw_blocks: Sequence[bytes]) -> None:
         '''Backup the raw blocks and flush.

--- a/src/electrumx/server/block_processor.py
+++ b/src/electrumx/server/block_processor.py
@@ -12,6 +12,8 @@
 import asyncio
 import concurrent.futures
 from concurrent.futures import ThreadPoolExecutor
+from functools import partial
+import sys
 import time
 from typing import Sequence, Tuple, List, Callable, Optional, TYPE_CHECKING, Type, Set
 
@@ -194,6 +196,12 @@ class BlockProcessor:
         )
         self.logger = class_logger(__name__, self.__class__.__name__)
 
+        # Check if GIL is enabled.  note: instantiating the DB can force-enable the GIL
+        # if it imports compiled extensions that don't declare free-threading compatibility.
+        # By now, DB() init has already run, so no more changes are expected.
+        self._gil_enabled = sys._is_gil_enabled() if hasattr(sys, "_is_gil_enabled") else True
+        self.logger.info(f'Python GIL enabled: {self._gil_enabled}')
+
         # Meta
         self.next_cache_check = 0
         self.touched_hashxs = set()     # type: Set[bytes]
@@ -240,10 +248,12 @@ class BlockProcessor:
         if not raw_blocks:
             return
         first = self.height + 1
-        # blocks = [self.coin.block(raw_block, first + n)
-        #           for n, raw_block in enumerate(raw_blocks)]
-        blocks = self.pool_executor1.map(self.coin.block, raw_blocks, range(first, first + (len(raw_blocks))))
-        blocks = list(blocks)  # join threads
+        if self._gil_enabled:
+            blocks = [self.coin.block(raw_block, first + n)
+                      for n, raw_block in enumerate(raw_blocks)]
+        else:
+            blocks = self.pool_executor1.map(self.coin.block, raw_blocks, range(first, first + (len(raw_blocks))))
+            blocks = list(blocks)  # join threads
         headers = [block.header for block in blocks]
         hprevs = [self.coin.header_prevhash_rev(h) for h in headers]
         chain = [self.tip] + [self.coin.header_hash_rev(h) for h in headers[:-1]]
@@ -457,34 +467,42 @@ class BlockProcessor:
         self.tx_count = tx_num
 
         # process tx outputs
-        blk_process_outputs = []  # type: list[concurrent.futures.Future]
+        blk_process_outputs = []  # type: list[Callable[[], Callable[[], None]]]
         height = self.height
         for block in blocks:
             height += 1
-            fut = self.pool_executor1.submit(
+            func = partial(
                 self.advance_txs_process_outputs,
                 block.transactions,
                 height=height,
             )
-            blk_process_outputs.append(fut)
-        for fut in blk_process_outputs:
-            add_unflushed_hist = fut.result()
+            if self._gil_enabled:
+                blk_process_outputs.append(func)
+            else:
+                fut = self.pool_executor1.submit(func)
+                blk_process_outputs.append(lambda fut=fut: fut.result())
+        for func in blk_process_outputs:
+            add_unflushed_hist = func()
             add_unflushed_hist()
 
         # process tx inputs
-        blk_process_inputs = []  # type: list[concurrent.futures.Future]
+        blk_process_inputs = []  # type: list[Callable[[], Callable[[], None]]]
         height = self.height
         for block in blocks:
             height += 1
-            fut = self.pool_executor1.submit(
+            func = partial(
                 self.advance_txs_process_inputs,
                 block.transactions,
                 height=height,
                 add_undo_info=height >= min_height,
             )
-            blk_process_inputs.append(fut)
-        for fut in blk_process_inputs:
-            add_unflushed_hist = fut.result()
+            if self._gil_enabled:
+                blk_process_inputs.append(func)
+            else:
+                fut = self.pool_executor1.submit(func)
+                blk_process_inputs.append(lambda fut=fut: fut.result())
+        for func in blk_process_inputs:
+            add_unflushed_hist = func()
             add_unflushed_hist()
 
         height = self.height
@@ -546,10 +564,13 @@ class BlockProcessor:
             for tx_pos, tx in txs_chunk:
                 process_txouts_for_single_tx(tx_pos=tx_pos, tx=tx)
 
-        list(self.pool_executor2.map(
-            process_txouts_for_chunk,
-            chunks(list(enumerate(txs)), 200),
-        ))
+        if self._gil_enabled:
+            process_txouts_for_chunk(enumerate(txs))
+        else:
+            list(self.pool_executor2.map(
+                process_txouts_for_chunk,
+                chunks(list(enumerate(txs)), 200),
+            ))
 
         # -- barrier. all threads have been joined.
         for hashXs in hashXs_by_tx:
@@ -597,6 +618,8 @@ class BlockProcessor:
             for tx_pos, tx in txs_chunk:
                 process_txins_for_single_tx(tx_pos=tx_pos, tx=tx)
 
+        # we split this workload across threads regardless of self._gil_enabled,
+        # as spend_utxo() is disk-IO-bound:
         list(self.pool_executor2.map(
             process_txins_for_chunk,
             chunks(list(enumerate(txs)), 200),

--- a/src/electrumx/server/block_processor.py
+++ b/src/electrumx/server/block_processor.py
@@ -10,6 +10,7 @@
 
 
 import asyncio
+from concurrent.futures import ThreadPoolExecutor
 import time
 from typing import Sequence, Tuple, List, Callable, Optional, TYPE_CHECKING, Type, Set
 
@@ -467,7 +468,6 @@ class BlockProcessor:
             txs: Sequence[Tx],
             is_unspendable: Callable[[bytes], bool],
     ) -> Sequence[bytes]:
-        # TODO split into two funcs, first fund all outputs, second spend all inputs
         self.txids_rev.append(b''.join(tx.txid_rev for tx in txs))
 
         # Use local vars for speed in the loops
@@ -483,7 +483,7 @@ class BlockProcessor:
         _pack_sats = pack_satoshis_val
         _pack_txnum = pack_txnum
 
-        # Add the new UTXOs
+        # 1. process tx outputs: fund UTXOs
         for tx, hashXs in zip(txs, hashXs_by_tx):
             txid_rev = tx.txid_rev
             add_hashXs = hashXs.append
@@ -502,9 +502,9 @@ class BlockProcessor:
                 add_touched_outpoint((txid_rev, idx))
             tx_num += 1
 
-        # Spend the inputs
-        # A separate for-loop here allows any tx ordering in block.
-        for tx_pos, tx in enumerate(txs):
+        # 2. process tx inputs: spend UTXOs
+        # note: we don't care about tx ordering in the block
+        def process_txins_for_single_tx(tx_pos: int, tx: Tx) -> None:
             add_hashXs = hashXs_by_tx[tx_pos].append
             tx_undo_info = []  # type: list[bytes]
             tx_undo_info_append = tx_undo_info.append
@@ -517,6 +517,15 @@ class BlockProcessor:
                 prevout_tuple = (txin.prev_txid_rev, txin.prev_idx)
                 add_touched_outpoint(prevout_tuple)
             bl_undo_info[tx_pos] = b"".join(tx_undo_info)
+
+        def process_txins_for_chunk(txs_chunk):
+            for tx_pos, tx in txs_chunk:
+                process_txins_for_single_tx(tx_pos=tx_pos, tx=tx)
+
+        list(self.pool_executor.map(
+            process_txins_for_chunk,
+            chunks(list(enumerate(txs)), 200),
+        ))
 
         # Update touched set for notifications
         for hashXs in hashXs_by_tx:
@@ -756,15 +765,16 @@ class BlockProcessor:
         '''
         self._caught_up_event = caught_up_event
         await self._first_open_dbs()
-        try:
-            async with OldTaskGroup() as group:
-                await group.spawn(self.prefetcher.main_loop(self.height))
-                await group.spawn(self._process_prefetched_blocks())
-        # Don't flush for arbitrary exceptions as they might be a cause or consequence of
-        # corrupted data
-        except CancelledError:
-            self.logger.info('flushing to DB for a clean shutdown...')
-            await self.flush(True)
+        with ThreadPoolExecutor() as self.pool_executor:
+            try:
+                async with OldTaskGroup() as group:
+                    await group.spawn(self.prefetcher.main_loop(self.height))
+                    await group.spawn(self._process_prefetched_blocks())
+            # Don't flush for arbitrary exceptions as they might be a cause or consequence of
+            # corrupted data
+            except CancelledError:
+                self.logger.info('flushing to DB for a clean shutdown...')
+                await self.flush(True)
 
     def force_chain_reorg(self, count: int) -> bool:
         '''Force a reorg of the given number of blocks.

--- a/src/electrumx/server/block_processor.py
+++ b/src/electrumx/server/block_processor.py
@@ -459,20 +459,27 @@ class BlockProcessor:
         height = self.height
         for block in blocks:
             height += 1
+            tx_num_start = self.db.tx_counts[height-1] if height > 0 else 0
             is_unspendable = (is_unspendable_genesis if height >= genesis_activation
                               else is_unspendable_legacy)
-            tx_num_start = self.db.tx_counts[height-1] if height > 0 else 0
-            self.advance_txs_process_outputs(
+            add_unflushed_hist1 = self.advance_txs_process_outputs(
                 block.transactions,
                 tx_num_start=tx_num_start,
                 is_unspendable=is_unspendable,
             )
-            self.advance_txs_process_inputs(
+            add_unflushed_hist1()
+
+        height = self.height
+        for block in blocks:
+            height += 1
+            tx_num_start = self.db.tx_counts[height - 1] if height > 0 else 0
+            add_unflushed_hist2 = self.advance_txs_process_inputs(
                 block.transactions,
                 tx_num_start=tx_num_start,
                 height=height,
                 add_undo_info=height >= min_height,
             )
+            add_unflushed_hist2()
 
         height = self.height
         for block in blocks:
@@ -494,7 +501,7 @@ class BlockProcessor:
             *,
             is_unspendable: Callable[[bytes], bool],
             tx_num_start: int,
-    ) -> None:
+    ) -> Callable[[], None]:
 
         # Use local vars for speed in the loops
         script_hashX = self.coin.hashX_from_script
@@ -537,7 +544,8 @@ class BlockProcessor:
         # -- barrier. all threads have been joined.
         for hashXs in hashXs_by_tx:
             update_touched_hashxs(hashXs)
-        self.db.history.add_unflushed(hashXs_by_tx, tx_num_start, bump_tx_count_next=False)
+
+        return lambda: self.db.history.add_unflushed(hashXs_by_tx, tx_num_start, bump_tx_count_next=False)
 
     def advance_txs_process_inputs(
             self,
@@ -546,7 +554,7 @@ class BlockProcessor:
             tx_num_start: int,
             height: int,
             add_undo_info: bool,
-    ) -> None:
+    ) -> Callable[[], None]:
 
         # Use local vars for speed in the loops
         bl_undo_info = [b"" for _ in txs]  # type: list[bytes]
@@ -586,10 +594,11 @@ class BlockProcessor:
         # -- barrier. all threads have been joined.
         for hashXs in hashXs_by_tx:
             update_touched_hashxs(hashXs)
-        self.db.history.add_unflushed(hashXs_by_tx, tx_num_start, bump_tx_count_next=True)
 
         if add_undo_info:
             self.undo_infos[height] = bl_undo_info
+
+        return lambda: self.db.history.add_unflushed(hashXs_by_tx, tx_num_start, bump_tx_count_next=True)
 
     def backup_blocks(self, raw_blocks: Sequence[bytes]) -> None:
         '''Backup the raw blocks and flush.

--- a/src/electrumx/server/block_processor.py
+++ b/src/electrumx/server/block_processor.py
@@ -486,7 +486,7 @@ class BlockProcessor:
         _pack_txnum = pack_txnum
 
         # 1. process tx outputs: fund UTXOs
-        for tx_pos, tx in enumerate(txs):
+        def process_txouts_for_single_tx(tx_pos: int, tx: Tx) -> None:
             txid_rev = tx.txid_rev
             add_hashXs = hashXs_by_tx[tx_pos].append
             tx_num = tx_num_start + tx_pos
@@ -504,6 +504,16 @@ class BlockProcessor:
                          hashX + tx_numb + _pack_sats(txout.value))
                 add_touched_outpoint((txid_rev, idx))
 
+        def process_txouts_for_chunk(txs_chunk):
+            for tx_pos, tx in txs_chunk:
+                process_txouts_for_single_tx(tx_pos=tx_pos, tx=tx)
+
+        list(self.pool_executor.map(
+            process_txouts_for_chunk,
+            chunks(list(enumerate(txs)), 200),
+        ))
+
+        # -- barrier. all threads have been joined.
         # 2. process tx inputs: spend UTXOs
         # note: we don't care about tx ordering in the block
         def process_txins_for_single_tx(tx_pos: int, tx: Tx) -> None:
@@ -529,6 +539,7 @@ class BlockProcessor:
             chunks(list(enumerate(txs)), 200),
         ))
 
+        # -- barrier. all threads have been joined.
         # Update touched set for notifications
         for hashXs in hashXs_by_tx:
             update_touched_hashxs(hashXs)

--- a/src/electrumx/server/block_processor.py
+++ b/src/electrumx/server/block_processor.py
@@ -465,9 +465,10 @@ class BlockProcessor:
             tx_num += len(block.transactions)
             self.db.tx_counts.append(tx_num)
         self.tx_count = tx_num
+        self.db.history.update_tx_count_next(tx_num)
 
         # process tx outputs
-        blk_process_outputs = []  # type: list[Callable[[], Callable[[], None]]]
+        blk_process_outputs = []  # type: list[Callable[[], None]]
         height = self.height
         for block in blocks:
             height += 1
@@ -482,11 +483,10 @@ class BlockProcessor:
                 fut = self.pool_executor1.submit(func)
                 blk_process_outputs.append(lambda fut=fut: fut.result())
         for func in blk_process_outputs:
-            add_unflushed_hist = func()
-            add_unflushed_hist()
+            func()
 
         # process tx inputs
-        blk_process_inputs = []  # type: list[Callable[[], Callable[[], None]]]
+        blk_process_inputs = []  # type: list[Callable[[], None]]
         height = self.height
         for block in blocks:
             height += 1
@@ -502,8 +502,7 @@ class BlockProcessor:
                 fut = self.pool_executor1.submit(func)
                 blk_process_inputs.append(lambda fut=fut: fut.result())
         for func in blk_process_inputs:
-            add_unflushed_hist = func()
-            add_unflushed_hist()
+            func()
 
         height = self.height
         for block in blocks:
@@ -524,7 +523,7 @@ class BlockProcessor:
             txs: Sequence[Tx],
             *,
             height: int,
-    ) -> Callable[[], None]:
+    ) -> None:
 
         tx_num_start = self.db.tx_counts[height - 1] if height > 0 else 0
         is_unspendable = (
@@ -576,7 +575,7 @@ class BlockProcessor:
         for hashXs in hashXs_by_tx:
             update_touched_hashxs(hashXs)
 
-        return lambda: self.db.history.add_unflushed(hashXs_by_tx, tx_num_start, bump_tx_count_next=False)
+        self.db.history.add_unflushed(hashXs_by_tx, tx_num_start)
 
     def advance_txs_process_inputs(
             self,
@@ -584,7 +583,7 @@ class BlockProcessor:
             *,
             height: int,
             add_undo_info: bool,
-    ) -> Callable[[], None]:
+    ) -> None:
 
         tx_num_start = self.db.tx_counts[height - 1] if height > 0 else 0
 
@@ -632,7 +631,7 @@ class BlockProcessor:
         if add_undo_info:
             self.undo_infos[height] = bl_undo_info
 
-        return lambda: self.db.history.add_unflushed(hashXs_by_tx, tx_num_start, bump_tx_count_next=True)
+        self.db.history.add_unflushed(hashXs_by_tx, tx_num_start)
 
     def backup_blocks(self, raw_blocks: Sequence[bytes]) -> None:
         '''Backup the raw blocks and flush.

--- a/src/electrumx/server/block_processor.py
+++ b/src/electrumx/server/block_processor.py
@@ -208,7 +208,7 @@ class BlockProcessor:
         self.headers = []  # type: list[bytes]
         self._bhash_to_bheight = dict()  # type: dict[bytes, int]
         self.txids_rev = []  # type: List[bytes]
-        self.undo_infos = []  # type: List[Tuple[Sequence[bytes], int]]
+        self.undo_infos = dict()  # type: dict[int, Sequence[bytes]]
 
         # UTXO cache
         self.utxo_cache = {}
@@ -442,25 +442,42 @@ class BlockProcessor:
         assert self.state_lock.locked()
         assert blocks
         min_height = self.db.min_undo_height(self.daemon.cached_height())
-        height = self.height
         genesis_activation = self.coin.GENESIS_ACTIVATION
         coin = self.coin
 
+        tx_num = self.tx_count
+        height = self.height
         for block in blocks:
             height += 1
             header_hash = coin.header_hash_rev(block.header)
+            self._bhash_to_bheight[header_hash] = height
+            self.txids_rev.append(b''.join(tx.txid_rev for tx in block.transactions))
+            tx_num += len(block.transactions)
+            self.db.tx_counts.append(tx_num)
+        self.tx_count = tx_num
+
+        height = self.height
+        for block in blocks:
+            height += 1
             is_unspendable = (is_unspendable_genesis if height >= genesis_activation
                               else is_unspendable_legacy)
-            tx_num_start = self.tx_count
-            self.txids_rev.append(b''.join(tx.txid_rev for tx in block.transactions))
-            self.advance_txs_process_outputs(block.transactions, is_unspendable=is_unspendable, tx_num_start=tx_num_start)
-            undo_info = self.advance_txs_process_inputs(block.transactions, tx_num_start=tx_num_start)
-            self._bhash_to_bheight[header_hash] = height
-            tx_num_end = tx_num_start + len(block.transactions)
-            self.tx_count = tx_num_end
-            self.db.tx_counts.append(tx_num_end)
+            tx_num_start = self.db.tx_counts[height-1] if height > 0 else 0
+            self.advance_txs_process_outputs(
+                block.transactions,
+                tx_num_start=tx_num_start,
+                is_unspendable=is_unspendable,
+            )
+            self.advance_txs_process_inputs(
+                block.transactions,
+                tx_num_start=tx_num_start,
+                height=height,
+                add_undo_info=height >= min_height,
+            )
+
+        height = self.height
+        for block in blocks:
+            height += 1
             if height >= min_height:
-                self.undo_infos.append((undo_info, height))
                 self.db.write_raw_block(block.raw, height)
 
         headers = [block.header for block in blocks]
@@ -527,7 +544,9 @@ class BlockProcessor:
             txs: Sequence[Tx],
             *,
             tx_num_start: int,
-    ) -> Sequence[bytes]:
+            height: int,
+            add_undo_info: bool,
+    ) -> None:
 
         # Use local vars for speed in the loops
         bl_undo_info = [b"" for _ in txs]  # type: list[bytes]
@@ -569,7 +588,8 @@ class BlockProcessor:
             update_touched_hashxs(hashXs)
         self.db.history.add_unflushed(hashXs_by_tx, tx_num_start, bump_tx_count_next=True)
 
-        return bl_undo_info
+        if add_undo_info:
+            self.undo_infos[height] = bl_undo_info
 
     def backup_blocks(self, raw_blocks: Sequence[bytes]) -> None:
         '''Backup the raw blocks and flush.

--- a/src/electrumx/server/db.py
+++ b/src/electrumx/server/db.py
@@ -64,7 +64,7 @@ class FlushData:
     # The following are flushed to the UTXO DB if undo_infos is not None
     undo_infos: list[tuple[Sequence[bytes], int]]
     adds: dict[bytes, bytes]  # txid+out_idx -> hashX+tx_num+value_sats
-    deletes: list[bytes]  # b'h' db keys, and b'u' db keys
+    deletes: list[bytes]  # b'h' db keys, and b'u' db keys.  order does not matter
     tip: bytes
 
 

--- a/src/electrumx/server/db.py
+++ b/src/electrumx/server/db.py
@@ -62,7 +62,7 @@ class FlushData:
     bhash_to_bheight: dict[bytes, int]  # block_hash_rev -> block_height
     block_txids_rev: list[bytes]
     # The following are flushed to the UTXO DB if undo_infos is not None
-    undo_infos: list[tuple[Sequence[bytes], int]]
+    undo_infos: dict[int, Sequence[bytes]]  # height -> undo_info
     adds: dict[bytes, bytes]  # txid+out_idx -> hashX+tx_num+value_sats
     deletes: list[bytes]  # b'h' db keys, and b'u' db keys.  order does not matter
     tip: bytes
@@ -601,10 +601,10 @@ class DB:
         return self.utxo_db.get(self.undo_key(height))
 
     def flush_undo_infos(
-            self, batch_put, undo_infos: Sequence[Tuple[Sequence[bytes], int]]
+            self, batch_put, undo_infos: dict[int, Sequence[bytes]],
     ) -> None:
-        '''undo_infos is a list of (undo_info, height) pairs.'''
-        for undo_info, height in undo_infos:
+        '''undo_infos is a (height -> undo_info) map.'''
+        for height, undo_info in undo_infos.items():
             batch_put(self.undo_key(height), b''.join(undo_info))
 
     def raw_block_prefix(self) -> str:

--- a/src/electrumx/server/history.py
+++ b/src/electrumx/server/history.py
@@ -133,18 +133,15 @@ class History:
             self,
             hashXs_by_tx: list[list[bytes]],
             first_tx_num: int,
-            *,
-            bump_tx_count_next: bool,
     ) -> None:
         unflushed = self.unflushed
-        tx_num = None
         for tx_num, hashXs in enumerate(hashXs_by_tx, start=first_tx_num):
             tx_numb = pack_txnum(tx_num)
             for hashX in hashXs:
                 unflushed.add(hashX + tx_numb)
-        if tx_num is not None and bump_tx_count_next:
-            assert self.hist_db_tx_count_next + len(hashXs_by_tx) == tx_num + 1
-            self.hist_db_tx_count_next = tx_num + 1
+
+    def update_tx_count_next(self, tx_count: int) -> None:
+        self.hist_db_tx_count_next = tx_count
 
     def unflushed_memsize(self) -> int:
         # note: the magic numbers here were estimated using util.deep_getsizeof

--- a/src/electrumx/server/history.py
+++ b/src/electrumx/server/history.py
@@ -129,7 +129,13 @@ class History:
         }
         batch.put(self.DB_STATE_KEY, repr(state).encode())
 
-    def add_unflushed(self, hashXs_by_tx: list[list[bytes]], first_tx_num: int) -> None:
+    def add_unflushed(
+            self,
+            hashXs_by_tx: list[list[bytes]],
+            first_tx_num: int,
+            *,
+            bump_tx_count_next: bool,
+    ) -> None:
         unflushed = self.unflushed
         count = 0
         tx_num = None
@@ -140,7 +146,7 @@ class History:
                 unflushed[hashX] += tx_numb
             count += len(hashXs)
         self.unflushed_count += count
-        if tx_num is not None:
+        if tx_num is not None and bump_tx_count_next:
             assert self.hist_db_tx_count_next + len(hashXs_by_tx) == tx_num + 1
             self.hist_db_tx_count_next = tx_num + 1
 

--- a/src/electrumx/server/history.py
+++ b/src/electrumx/server/history.py
@@ -16,6 +16,7 @@ from collections import defaultdict
 from typing import TYPE_CHECKING, Type, Optional, Sequence, Iterable
 
 import electrumx.lib.util as util
+from electrumx.lib.hash import HASHX_LEN
 from electrumx.server.db_util import (
     DBTooOldForMigrations,
     pack_txnum, unpack_txnum, TXNUM_LEN,
@@ -34,8 +35,7 @@ class History:
 
     def __init__(self):
         self.logger = util.class_logger(__name__, self.__class__.__name__)
-        self.unflushed = defaultdict(bytearray)
-        self.unflushed_count = 0
+        self.unflushed = set()  # type: set[bytes]
         self.hist_db_tx_count = 0
         self.hist_db_tx_count_next = 0  # after next flush, next value for self.hist_db_tx_count
         self.db_version = max(self.DB_VERSIONS)
@@ -137,21 +137,18 @@ class History:
             bump_tx_count_next: bool,
     ) -> None:
         unflushed = self.unflushed
-        count = 0
         tx_num = None
         for tx_num, hashXs in enumerate(hashXs_by_tx, start=first_tx_num):
             tx_numb = pack_txnum(tx_num)
-            hashXs = set(hashXs)
             for hashX in hashXs:
-                unflushed[hashX] += tx_numb
-            count += len(hashXs)
-        self.unflushed_count += count
+                unflushed.add(hashX + tx_numb)
         if tx_num is not None and bump_tx_count_next:
             assert self.hist_db_tx_count_next + len(hashXs_by_tx) == tx_num + 1
             self.hist_db_tx_count_next = tx_num + 1
 
     def unflushed_memsize(self) -> int:
-        return len(self.unflushed) * 180 + self.unflushed_count * TXNUM_LEN
+        # note: the magic numbers here were estimated using util.deep_getsizeof
+        return len(self.unflushed) * 85 + len(self.unflushed) * (HASHX_LEN + TXNUM_LEN)
 
     def assert_flushed(self) -> None:
         assert not self.unflushed
@@ -159,24 +156,21 @@ class History:
     def flush(self) -> None:
         start_time = time.monotonic()
         unflushed = self.unflushed
-        chunks = util.chunks
 
         with self.db.write_batch() as batch:
-            for hashX in sorted(unflushed):
-                for tx_num in chunks(unflushed[hashX], TXNUM_LEN):
-                    db_key = b'H' + hashX + tx_num
-                    batch.put(db_key, b'')
+            for hashX_txnum in sorted(unflushed):
+                db_key = b'H' + hashX_txnum
+                batch.put(db_key, b'')
             self.hist_db_tx_count = self.hist_db_tx_count_next
             self._write_state(batch)
 
         count = len(unflushed)
         unflushed.clear()
-        self.unflushed_count = 0
 
         if self.db.for_sync:
             elapsed = time.monotonic() - start_time
             self.logger.info(f'flushed history in {elapsed:.1f}s '
-                             f'for {count:,d} addrs')
+                             f'for {count:,d} history entries')
 
     def backup(self, *, hashXs: Iterable[bytes], tx_count: int) -> None:
         self.assert_flushed()

--- a/src/electrumx/server/history.py
+++ b/src/electrumx/server/history.py
@@ -134,6 +134,7 @@ class History:
             hashXs_by_tx: list[list[bytes]],
             first_tx_num: int,
     ) -> None:
+        """This method must be thread-safe. (runs on bp.pool_executor)"""
         unflushed = self.unflushed
         for tx_num, hashXs in enumerate(hashXs_by_tx, start=first_tx_num):
             tx_numb = pack_txnum(tx_num)


### PR DESCRIPTION
Split block processing work across a thread-pool.

There are two kinds of performance we should consider:
1. wall clock time for first sync from genesis
2. wall clock time it takes to process a single block when already at the tip
    - check the logs: `grep BlockProcessor`, e.g.:
        ```
        DEBUG:BlockProcessor:new height: 955368
        INFO:BlockProcessor:processed 1 block size 1.72 MB in 2.4s
        ```
    - on master (and for the past several years), there has been *a lot* of variance for how long this takes. On my server, it is typically around 2 seconds, but 10+ seconds is not that rare either. The max I saw was 30 seconds at one point! That's a lot.

-----

I have been experimenting running ElectrumX with a free-threaded cpython (compiled with `--disable-gil`), and running [with `PYTHON_GIL=0` at runtime](https://github.com/spesmilo/electrumx/issues/371). Normally Python has a Global Interpreter Lock, which means in practice only one thread can do work on the CPU, i.e. single core CPU performance is often the bottleneck for many workloads.

Since Python 3.13, it is possible to [run cpython without the GIL](https://docs.python.org/3/howto/free-threading-python.html).

-----

On master, the BlockProcessor is completely single-threaded. It processes blocks in order.
For each block, it processes txs in order. For each tx:
- it processes the tx inputs in order: spending utxos (calling `spend_utxo`)
- it processes the tx outputs in order: funding utxos

Part of the reason for the huge variance in time needed for (2), is `spend_utxo` hitting the disk. `spend_utxo` does a blocking read in RocksDB (or LevelDB), which might hit the RocksDB cache, or might hit the OS cache, or finally might have to go and read the disk. For a single block with 5k txs, each with 5 inputs, `spend_utxo` might hit the disk 25k times, sequentially. (though such an extreme example is unlikely: the caches will get warmed)

This PR changes the block processing logic to process txs out-of-order within a single block:
- first, concurrently process all the outputs, funding utxos
- second, concurrently process all the inputs, spending utxos
- we disregard the possibility that this way a utxo might be spent before it gets created: we trust bitcoind to have already validated consensus rules

As the `spend_utxo` codepath is disk-read-bottlenecked, this should improve the performance regardless of the GIL.

-----

In case the GIL is disabled, this PR also parallelises a lot of the CPU-bottlenecked calculations.

However, I have found that doing this unconditionally makes performance of (1) significantly slower in the GIL-enabled traditional scenario (`tx/sec since genesis: 7,923 (height: 785,897)`, see later). Hence, we maintain two distinct code paths and branch at runtime depending on whether the GIL is enabled.

-----

Measured performance of this PR compared to master (using RocksDB 9):
- sync from genesis (1):
    - master, GIL enabled: `tx/sec since genesis: 10,282 (height 955,147)`
    - this PR, GIL enabled: `tx/sec since genesis: 9,766 (height 783,693)`
    - this PR, GIL disabled: `tx/sec since genesis: 22,413 (height 955,333)`
- single block at tip (2):
    - master, GIL enabled: `(min=0.2 sec, avg=1.275 sec, max=3.4 sec, num_blocks=222)`
    - this PR*, GIL enabled: `(min=0.1 sec, avg=0.633 sec, max=2.4 sec, num_blocks=221)`
        - (tested using a previous version of this PR that should be similar enough)
    - this PR, GIL disabled: `(min=0.2 sec, avg=0.514 sec, max=1.9 sec, num_blocks=44)`

Memory usage: during sync from genesis, with the GIL disabled, due to the massive parallelization significantly more RAM is needed. I was testing with the default `CACHE_MB=1200`: with the GIL, memory usage hovers around 2 GB, while without it is around 8 GB.

-----

For now, running ElectrumX with the GIL disabled is to be considered experimental. However, it seemed to work for me :)
    
-----

generic perf baseline from master for my own reference (using https://github.com/sombernight/electrumx/commit/b3ff9f9b381540460737287c08c3ba658f714fab):
```
DEBUG:BlockProcessor:new height: 712588
DEBUG:BlockProcessor:total times:
ch_adv_bl=48254.05 (
  block_deser=12296.57,
  adv_bl=26595.92 (
      adv_tx=26512.74 (
          spend_utxo=16470.37,
      ),
  ),
  flush=8220.05,
),
prefetch_blocks=4578.71,
```
