### PR TITLE
json: replace unmaintained ujson/rapidjson extras with orjson

### DIFF
--- a/docs/HOWTO.rst
+++ b/docs/HOWTO.rst
@@ -101,9 +101,9 @@ You can install with::
 
 There are many extra Python dependencies available to fit the needs of your
 system or coins. For example, to install the RocksDB dependencies and a faster
-JSON parsing library::
+JSON (de)serialization library::
 
-    pip3 install ".[rocksdb,ujson]"
+    pip3 install ".[rocksdb,orjson]"
 
 see pyproject.toml's ``project.optional-dependencies`` for a complete list.
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -48,6 +48,9 @@ TODO expand
 * protocol:
    - new: implement electrum protocol version 1.7  (`spesmilo/electrum-protocol#2`_).
      The min supported protocol version remains 1.4, the max is now 1.7.
+* performance: json (de)serialization can now optionally use the Rust-based
+  :code:`orjson` library (via the :code:`orjson` pip extra), replacing the
+  previous :code:`ujson` and :code:`rapidjson` extras.
 
 
 Version 1.20.0 (03 June 2026)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,11 +51,8 @@ rocksdb = [
 dev = [
     "objgraph",
 ]
-rapidjson = [
-    "python-rapidjson>=0.4.1,<2.0",
-]
-ujson = [
-    "ujson>=2.0.0,<4.0.0",
+orjson = [
+    "orjson>=3,<4",
 ]
 uvloop = [
     "uvloop>=0.14",

--- a/src/electrumx/lib/util.py
+++ b/src/electrumx/lib/util.py
@@ -28,29 +28,29 @@
 
 
 from array import array
-import asyncio
 import inspect
 from ipaddress import ip_address
 import logging
 import sys
 from collections.abc import Container, Mapping
 from struct import Struct
-from typing import Set, Any
+from typing import Any
 
 import aiorpcx
 
 
-# Use system-compiled JSON lib if available, fallback to stdlib
+# Use orjson (faster 3rd party library) if available, fallback to stdlib
 try:
-    import rapidjson as json
-except ImportError:
-    try:
-        import ujson as json
-    except ImportError:
-        import json
+    import orjson
+    json_deserialize = orjson.loads
 
-json_deserialize = json.loads
-json_serialize = json.dumps
+    def json_serialize(obj: Any) -> str:
+        return orjson.dumps(obj).decode()  # orjson.dumps() returns bytes
+except ImportError:
+    import json
+    json_deserialize = json.loads
+    json_serialize = json.dumps
+
 
 # Logging utilities
 

--- a/tests/lib/test_util.py
+++ b/tests/lib/test_util.py
@@ -220,3 +220,19 @@ def test_pack_varbytes():
         data = util.pack_varbytes(test)
         deser = tx.Deserializer(data)
         assert deser._read_varbytes() == test
+
+def test_json_serialize_deserialize():
+    obj = {
+        'coin': 'Bitcoin',
+        'height': 950000,
+        'counts': {'getblock': 2},
+        'nested': {'list': [1, 2, 3], 'flag': True, 'none': None},
+    }
+    serialized = util.json_serialize(obj)
+    assert isinstance(serialized, str)
+    assert util.json_deserialize(serialized) == {
+        'coin': 'Bitcoin',
+        'height': 950000,
+        'counts': {'getblock': 2},
+        'nested': {'list': [1, 2, 3], 'flag': True, 'none': None},
+    }


### PR DESCRIPTION
ujson and rapidjson were both rather unmaintained and potentially even slower than modern python stdlib json. 
Replace them with the maintained and performant orjson library as extra instead.