### PR TITLE
env: COIN no longer mandatory, defaults to "Bitcoin", again

### DIFF
--- a/docs/environment.rst
+++ b/docs/environment.rst
@@ -168,9 +168,9 @@ Here are some examples of valid services::
 
   Here is an example value of the :envvar:`REPORT_SERVICES` environment variable::
 
-    tcp://sv.usebsv.com:50001,ssl://sv.usebsv.com:50002,wss://sv.usebsv.com:50004
+    tcp://example.com:50001,ssl://example.com:50002,wss://example.com:50004
 
-  This advertizes **tcp**, **ssl**, **wss** services at :const:`sv.usebsv.com` on ports
+  This advertizes **tcp**, **ssl**, **wss** services at :const:`example.com` on ports
   50001, 50002 and 50004 respectively.
 
 .. note:: Certificate Authority-signed certificates don't work over Tor, so you should

--- a/docs/environment.rst
+++ b/docs/environment.rst
@@ -19,11 +19,6 @@ Required
 
 These environment variables are always required:
 
-.. envvar:: COIN
-
-  Must be a :attr:`NAME` from one of the :class:`Coin` classes in
-  `lib/coins.py`_. For example, ``Bitcoin``.
-
 .. envvar:: DB_DIRECTORY
 
   The path to the database directory.  Relative paths should be
@@ -194,6 +189,16 @@ Miscellaneous
 
 These environment variables are optional:
 
+.. envvar:: COIN
+
+  Must be a :attr:`NAME` from one of the :class:`Coin` classes in
+  `lib/coins.py`_.  Defaults to ``Bitcoin``.
+
+.. envvar:: NET
+
+  Must be a :attr:`NET` from one of the :class:`Coin` classes in
+  `lib/coins.py`_.  Defaults to ``mainnet``.
+
 .. envvar:: LOG_FORMAT
 
   The Python logging `format string
@@ -209,11 +214,6 @@ These environment variables are optional:
 
   Set this environment variable to anything non-empty to allow running
   ElectrumX as root.
-
-.. envvar:: NET
-
-  Must be a :envvar:`NET` from one of the **Coin** classes in
-  `lib/coins.py`_.  Defaults to ``mainnet``.
 
 .. envvar:: DONATION_ADDRESS
 

--- a/src/electrumx/server/env.py
+++ b/src/electrumx/server/env.py
@@ -52,7 +52,7 @@ class Env(EnvBase):
             assert issubclass(coin, Coin)
             self.coin = coin
         else:
-            coin_name = self.required('COIN').strip()
+            coin_name = self.default('COIN', 'Bitcoin').strip()
             network = self.default('NET', 'mainnet').strip()
             self.coin = Coin.lookup_coin_class(coin_name, network)
 

--- a/tests/server/test_env.py
+++ b/tests/server/test_env.py
@@ -18,7 +18,6 @@ base_environ = {
     'DB_DIRECTORY': BASE_DB_DIR,
     'DB_ENGINE': 'rocksdb',
     'DAEMON_URL': BASE_DAEMON_URL,
-    'COIN': 'Bitcoin',
 }
 
 

--- a/tests/server/test_env.py
+++ b/tests/server/test_env.py
@@ -18,7 +18,7 @@ base_environ = {
     'DB_DIRECTORY': BASE_DB_DIR,
     'DB_ENGINE': 'rocksdb',
     'DAEMON_URL': BASE_DAEMON_URL,
-    'COIN': 'BitcoinSV',
+    'COIN': 'Bitcoin',
 }
 
 
@@ -92,13 +92,13 @@ def test_COIN_NET():
     '''Test COIN and NET defaults and redirection.'''
     setup_base_env()
     e = Env()
-    assert e.coin == lib_coins.BitcoinSV
+    assert e.coin == lib_coins.BitcoinMainnet
     os.environ['NET'] = 'testnet'
     e = Env()
-    assert e.coin == lib_coins.BitcoinSVTestnet
+    assert e.coin == lib_coins.BitcoinTestnet3
     os.environ['NET'] = ' testnet '
     e = Env()
-    assert e.coin == lib_coins.BitcoinSVTestnet
+    assert e.coin == lib_coins.BitcoinTestnet3
     os.environ.pop('NET')
     os.environ['COIN'] = ' Litecoin '
     e = Env()
@@ -274,7 +274,7 @@ def test_REPORT_SERVICES_localhost():
 
 def test_REORG_LIMIT():
     assert_integer('REORG_LIMIT', 'reorg_limit',
-                   lib_coins.BitcoinSV.REORG_LIMIT)
+                   lib_coins.Bitcoin.REORG_LIMIT)
 
 
 def test_COST_HARD_LIMIT():
@@ -427,5 +427,5 @@ def test_ban_versions():
 
 
 def test_coin_class_provided():
-    e = Env(lib_coins.BitcoinSV)
-    assert e.coin == lib_coins.BitcoinSV
+    e = Env(lib_coins.Bitcoin)
+    assert e.coin == lib_coins.Bitcoin


### PR DESCRIPTION
default was previously removed in https://github.com/spesmilo/electrumx/commit/3cc5b5ea43f64dc3b3bffd4e42def0ef8b3bfb54, around bcash fork