### PR TITLE
mempool: reduce worst-case time complexity: topological-sort candidates

### DIFF
--- a/src/electrumx/lib/tx.py
+++ b/src/electrumx/lib/tx.py
@@ -125,6 +125,9 @@ class TXOSpendStatus:
         assert (self.spender_txid_rev is not None) == (self.spender_height is not None), (self.spender_txid_rev, self.spender_height)
 
 
+TxOutpoint = tuple[bytes, int]  # (txid_rev, txout_idx)
+
+
 class Deserializer:
     '''Deserializes blocks into transactions.
 

--- a/src/electrumx/server/block_processor.py
+++ b/src/electrumx/server/block_processor.py
@@ -26,7 +26,7 @@ from electrumx.lib.script import is_unspendable_legacy, is_unspendable_genesis
 from electrumx.lib.util import (
     chunks, class_logger, OldTaskGroup,
 )
-from electrumx.lib.tx import Tx
+from electrumx.lib.tx import Tx, TxOutpoint
 from electrumx.server.db import FlushData, COMP_TXID_LEN, DB
 from electrumx.server.db_util import (
     pack_txnum, unpack_txnum, TXNUM_LEN,
@@ -205,7 +205,7 @@ class BlockProcessor:
         # Meta
         self.next_cache_check = 0
         self.touched_hashxs = set()     # type: Set[bytes]
-        self.touched_outpoints = set()  # type: Set[Tuple[bytes, int]]
+        self.touched_outpoints = set()  # type: Set[TxOutpoint]
         self.reorg_count = 0
         self.height = -1
         self.tip = None  # type: Optional[bytes]  # block_hash_rev

--- a/src/electrumx/server/controller.py
+++ b/src/electrumx/server/controller.py
@@ -13,6 +13,7 @@ from aiorpcx import _version as aiorpcx_version
 import electrumx
 from electrumx.lib.server_base import ServerBase
 from electrumx.lib.util import version_string, OldTaskGroup
+from electrumx.lib.tx import TxOutpoint
 from electrumx.server.db import DB
 from electrumx.server.mempool import MemPool, MemPoolAPI
 from electrumx.server.session import SessionManager
@@ -34,8 +35,8 @@ class Notifications:
     def __init__(self):
         self._touched_hashxs_mp = {}  # type: Dict[int, Set[bytes]]
         self._touched_hashxs_bp = {}  # type: Dict[int, Set[bytes]]
-        self._touched_outpoints_mp = {}  # type: Dict[int, Set[Tuple[bytes, int]]]
-        self._touched_outpoints_bp = {}  # type: Dict[int, Set[Tuple[bytes, int]]]
+        self._touched_outpoints_mp = {}  # type: Dict[int, Set[TxOutpoint]]
+        self._touched_outpoints_bp = {}  # type: Dict[int, Set[TxOutpoint]]
         self._highest_block = -1
 
     async def _maybe_notify(self):
@@ -75,7 +76,7 @@ class Notifications:
             self,
             *,
             touched_hashxs: Set[bytes],
-            touched_outpoints: Set[Tuple[bytes, int]],
+            touched_outpoints: Set[TxOutpoint],
             height: int,
     ):
         pass
@@ -93,7 +94,7 @@ class Notifications:
             self,
             *,
             touched_hashxs: Set[bytes],
-            touched_outpoints: Set[Tuple[bytes, int]],
+            touched_outpoints: Set[TxOutpoint],
             height: int,
     ):
         self._touched_hashxs_mp[height] = touched_hashxs
@@ -104,7 +105,7 @@ class Notifications:
             self,
             *,
             touched_hashxs: Set[bytes],
-            touched_outpoints: Set[Tuple[bytes, int]],
+            touched_outpoints: Set[TxOutpoint],
             height: int,
     ):
         self._touched_hashxs_bp[height] = touched_hashxs

--- a/src/electrumx/server/mempool.py
+++ b/src/electrumx/server/mempool.py
@@ -30,6 +30,9 @@ if TYPE_CHECKING:
     from electrumx.lib.coins import Coin
 
 
+DB_UTXO_MAP = dict[tuple[bytes, int], Optional[tuple[bytes, int]]]  # prevout->(hashX,value_in_sats)
+
+
 @dataclass(slots=True)
 class MemPoolTx:
     prevouts: Sequence[tuple[bytes, int]]  # (txid_rev, txout_idx)
@@ -233,12 +236,11 @@ class MemPool:
             self,
             *,
             tx_map: Dict[bytes, MemPoolTx],  # txid_rev->tx
-            utxo_map: Dict[Tuple[bytes, int], Optional[Tuple[bytes, int]]],  # prevout->(hashX,value_in_sats)
+            utxo_map: DB_UTXO_MAP,  # prevout->(hashX,value_in_sats)
             touched_hashxs: Set[bytes],  # set of hashXs
             touched_outpoints: Set[Tuple[bytes, int]],  # set of outpoints
             topologically_sort: bool,
-    ) -> Tuple[Dict[bytes, MemPoolTx],
-               Dict[Tuple[bytes, int], Optional[Tuple[bytes, int]]]]:
+    ) -> tuple[dict[bytes, MemPoolTx], DB_UTXO_MAP]:
         '''Accept transactions in tx_map to the mempool if all their inputs
         can be found in the existing mempool or a utxo_map from the
         DB.
@@ -393,7 +395,7 @@ class MemPool:
                 raise DBSyncError
 
             tx_map = {}  # type: dict[bytes, MemPoolTx]
-            utxo_map = {}  # type: dict[tuple[bytes, int], tuple[bytes, int]]
+            utxo_map = {}  # type: DB_UTXO_MAP
             async for task in group:
                 partial_tx_map, partial_utxo_map = task.result()
                 tx_map.update(partial_tx_map)
@@ -433,8 +435,7 @@ class MemPool:
             *,
             new_txids_rev: set[bytes],  # (some) new candidate txs for our mempool
             all_txids_rev: set[bytes],  # complete view of daemon's mempool
-    ) -> tuple[dict[bytes, MemPoolTx],
-               dict[tuple[bytes, int], Optional[tuple[bytes, int]]]]:
+    ) -> tuple[dict[bytes, MemPoolTx], DB_UTXO_MAP]:
         '''Fetch a list of mempool transactions, and lookup corresponding UTXOs in the DB.'''
         txids_hum_iter = (hash_to_hex_str(hash) for hash in new_txids_rev)
         raw_txs = await self.api.raw_transactions(txids_hum_iter)

--- a/src/electrumx/server/mempool.py
+++ b/src/electrumx/server/mempool.py
@@ -23,19 +23,19 @@ from aiorpcx import run_in_thread, sleep, ignore_after
 from electrumx.lib.hash import hash_to_hex_str, hex_str_to_hash
 from electrumx.lib.tx import SkipTxDeserialize
 from electrumx.lib.util import class_logger, chunks, OldTaskGroup
-from electrumx.lib.tx import TXOSpendStatus
+from electrumx.lib.tx import TXOSpendStatus, TxOutpoint
 from electrumx.server.db import UTXO
 
 if TYPE_CHECKING:
     from electrumx.lib.coins import Coin
 
 
-DB_UTXO_MAP = dict[tuple[bytes, int], Optional[tuple[bytes, int]]]  # prevout->(hashX,value_in_sats)
+DB_UTXO_MAP = dict[TxOutpoint, Optional[tuple[bytes, int]]]  # prevout->(hashX,value_in_sats)
 
 
 @dataclass(slots=True)
 class MemPoolTx:
-    prevouts: Sequence[tuple[bytes, int]]  # (txid_rev, txout_idx)
+    prevouts: Sequence[TxOutpoint]  # (txid_rev, txout_idx)
     # A pair is a (hashX, value) tuple
     in_pairs: Optional[Sequence[tuple[bytes, int]]]  # (hashX, value_in_sats)
     out_pairs: Sequence[tuple[bytes, int]]  # (hashX, value_in_sats)
@@ -96,7 +96,7 @@ class MemPoolAPI(ABC):
         txids_hum is an iterable of hexadecimal hash strings.'''
 
     @abstractmethod
-    async def lookup_utxos(self, prevouts: Sequence[Tuple[bytes, int]]) -> Sequence[Optional[Tuple[bytes, int]]]:
+    async def lookup_utxos(self, prevouts: Sequence[TxOutpoint]) -> Sequence[Optional[Tuple[bytes, int]]]:
         '''Return a list of (hashX, value) pairs, one for each prevout if unspent,
         otherwise return None if spent or not found (for the given prevout).
 
@@ -108,7 +108,7 @@ class MemPoolAPI(ABC):
             self,
             *,
             touched_hashxs: Set[bytes],
-            touched_outpoints: Set[Tuple[bytes, int]],
+            touched_outpoints: Set[TxOutpoint],
             height: int,
     ):
         '''Called each time the mempool is synchronized.  touched_hashxs and
@@ -146,7 +146,7 @@ class MemPool:
         self.logger = class_logger(__name__, self.__class__.__name__)
         self.txs = {}  # type: Dict[bytes, MemPoolTx]  # txid_rev->tx
         self.hashXs = defaultdict(set)  # type: Dict[Optional[bytes], Set[bytes]]  # hashX->txids_rev
-        self.txo_to_spender = {}  # type: Dict[Tuple[bytes, int], bytes]  # prevout->txid_rev
+        self.txo_to_spender = {}  # type: Dict[TxOutpoint, bytes]  # prevout->txid_rev
         self.cached_compact_histogram = []  # type: Sequence[tuple[float, int]]
         self.refresh_secs = refresh_secs
         self.log_status_secs = log_status_secs
@@ -238,7 +238,7 @@ class MemPool:
             tx_map: Dict[bytes, MemPoolTx],  # txid_rev->tx
             utxo_map: DB_UTXO_MAP,  # prevout->(hashX,value_in_sats)
             touched_hashxs: Set[bytes],  # set of hashXs
-            touched_outpoints: Set[Tuple[bytes, int]],  # set of outpoints
+            touched_outpoints: Set[TxOutpoint],  # set of outpoints
             topologically_sort: bool,
     ) -> tuple[dict[bytes, MemPoolTx], DB_UTXO_MAP]:
         '''Accept transactions in tx_map to the mempool if all their inputs
@@ -351,7 +351,7 @@ class MemPool:
             *,
             all_txids_rev: Set[bytes],  # set of txids_rev
             touched_hashxs: Set[bytes],  # set of hashXs
-            touched_outpoints: Set[Tuple[bytes, int]],  # set of outpoints
+            touched_outpoints: Set[TxOutpoint],  # set of outpoints
             mempool_height: int,
     ) -> None:
         # Re-sync with the new set of hashes
@@ -516,7 +516,7 @@ class MemPool:
         '''Return a compact fee histogram of the current mempool.'''
         return self.cached_compact_histogram
 
-    async def potential_spends(self, hashX: bytes) -> set[tuple[bytes, int]]:
+    async def potential_spends(self, hashX: bytes) -> set[TxOutpoint]:
         '''Return a set of (prev_hash, prev_idx) pairs from mempool
         transactions that touch hashX.
 

--- a/src/electrumx/server/mempool.py
+++ b/src/electrumx/server/mempool.py
@@ -401,34 +401,30 @@ class MemPool:
                 tx_map.update(partial_tx_map)
                 utxo_map.update(partial_utxo_map)
 
-            # Accept candidate txs from tx_map into our mempool.
-            # We only accept candidates for which we can find a UTXO for each tx input:
-            # - some UTXOs we find in the DB=utxo_map (chainstate),
-            # - some we find in self.txs (our memool),
-            # - some we might only find in tx_map (among the candidates: consider long chain of unconfirmed txs)
-            # - some we might not find anywhere: if DB is corrupted or bitcoind gave inconsistent mempool, or other race
-            # In each iteration, we loop over tx_map and move accepted transactions from it to self.txs.
-            # In the worst degenerate case, this could be O(n^2). To avoid that, we topologically sort tx_map.
-            t0 = time.monotonic()
-            first_txmap_size = len(tx_map)
-            prior_txmap_size = 0
-            iter_count = 0
-            while tx_map and len(tx_map) != prior_txmap_size:
-                prior_txmap_size = len(tx_map)
-                tx_map, utxo_map = self._accept_transactions(
-                    tx_map=tx_map,
-                    utxo_map=utxo_map,
-                    touched_hashxs=touched_hashxs,
-                    touched_outpoints=touched_outpoints,
-                    topologically_sort=True,
-                )
-                iter_count += 1
-            time_elapsed = time.monotonic() - t0
-            if time_elapsed > 0.1:
-                self.logger.debug(
-                    f'accept_transactions() while-loop took {time_elapsed:.2f}s. txs={first_txmap_size}, {iter_count=}')
-            if tx_map:
-                self.logger.error(f'{len(tx_map)} txs dropped')
+            def accept_txs_loop() -> None:
+                # Accept candidate txs from tx_map into our mempool.
+                # We only accept candidates for which we can find a UTXO for each tx input:
+                # - some UTXOs we find in the DB=utxo_map (chainstate),
+                # - some we find in self.txs (our memool),
+                # - some we might only find in tx_map (among the candidates: consider long chain of unconfirmed txs)
+                # - some we might not find anywhere: if DB is corrupted or bitcoind gave inconsistent mempool, or other race
+                # In each iteration, we loop over tx_map and move accepted transactions from it to self.txs.
+                # In the worst degenerate case, this could be O(n^2). To avoid that, we topologically sort tx_map.
+                nonlocal tx_map, utxo_map
+                prior_txmap_size = 0
+                while tx_map and len(tx_map) != prior_txmap_size:
+                    prior_txmap_size = len(tx_map)
+                    tx_map, utxo_map = self._accept_transactions(
+                        tx_map=tx_map,
+                        utxo_map=utxo_map,
+                        touched_hashxs=touched_hashxs,
+                        touched_outpoints=touched_outpoints,
+                        topologically_sort=True,
+                    )
+                if tx_map:
+                    self.logger.error(f'{len(tx_map)} txs dropped')
+
+            await run_in_thread(accept_txs_loop)
 
     async def _fetch_raw_txs_and_utxos(
             self,

--- a/src/electrumx/server/mempool.py
+++ b/src/electrumx/server/mempool.py
@@ -349,7 +349,7 @@ class MemPool:
     async def _process_mempool(
             self,
             *,
-            all_txids_rev: Set[bytes],  # set of txids_rev
+            all_txids_rev: Set[bytes],  # set of txids_rev  # complete view of daemon's mempool
             touched_hashxs: Set[bytes],  # set of hashXs
             touched_outpoints: Set[TxOutpoint],  # set of outpoints
             mempool_height: int,
@@ -362,7 +362,7 @@ class MemPool:
         if mempool_height != self.api.db_height():  # FIXME should compare blockhash
             raise DBSyncError
 
-        # First handle txs that have disappeared
+        # 1. Handle txs that have disappeared (evicted, just got mined, etc)
         # TODO split disappeared txs workload into a threadpool, chunks of ~200 txs
         for txid_rev in (set(txs) - all_txids_rev):
             tx = txs.pop(txid_rev)
@@ -381,9 +381,10 @@ class MemPool:
             for out_idx, out_pair in enumerate(tx.out_pairs):
                 touched_outpoints.add((txid_rev, out_idx))
 
-        # Process new transactions
+        # 2. Process new transactions
         new_hashes = list(all_txids_rev.difference(txs))
         if new_hashes:
+            # 2.1. fetch raw txs from bitcoin daemon
             group = OldTaskGroup()
             for hashes in chunks(new_hashes, 200):
                 coro = self._fetch_raw_txs_and_utxos(
@@ -401,6 +402,7 @@ class MemPool:
                 tx_map.update(partial_tx_map)
                 utxo_map.update(partial_utxo_map)
 
+            # 2.2. accept txs into our mempool
             def accept_txs_loop() -> None:
                 # Accept candidate txs from tx_map into our mempool.
                 # We only accept candidates for which we can find a UTXO for each tx input:

--- a/src/electrumx/server/mempool.py
+++ b/src/electrumx/server/mempool.py
@@ -16,6 +16,7 @@ from collections import defaultdict
 from dataclasses import dataclass
 from typing import Sequence, Tuple, TYPE_CHECKING, Type, Dict, Optional, Set, Iterable
 import math
+from graphlib import TopologicalSorter
 
 from aiorpcx import run_in_thread, sleep, ignore_after
 
@@ -235,6 +236,7 @@ class MemPool:
             utxo_map: Dict[Tuple[bytes, int], Optional[Tuple[bytes, int]]],  # prevout->(hashX,value_in_sats)
             touched_hashxs: Set[bytes],  # set of hashXs
             touched_outpoints: Set[Tuple[bytes, int]],  # set of outpoints
+            topologically_sort: bool,
     ) -> Tuple[Dict[bytes, MemPoolTx],
                Dict[Tuple[bytes, int], Optional[Tuple[bytes, int]]]]:
         '''Accept transactions in tx_map to the mempool if all their inputs
@@ -247,10 +249,27 @@ class MemPool:
         txs = self.txs
         txo_to_spender = self.txo_to_spender
 
+        if topologically_sort:
+            # Sort tx_map so that parent txs come first (in case of unconf chain).
+            # This is just an optimization so that fewer txs will get "deferred", leading to better perf.
+            # Dependencies outside tx_map (already in chainstate (utxo_map), or our mempool (self.txs),
+            # or MISSING) are ignored.
+            cand_to_parents = {
+                txid: {parent_txid for (parent_txid, txout_idx) in tx.prevouts
+                       if parent_txid in tx_map}
+                for (txid, tx) in tx_map.items()}
+            cand_txids = list(TopologicalSorter(cand_to_parents).static_order())
+            assert len(tx_map) == len(cand_to_parents) == len(cand_txids), \
+                f"{len(tx_map)=}, {len(cand_to_parents)=}, {len(cand_txids)=}"
+            del cand_to_parents
+        else:
+            cand_txids = tx_map.keys()
+
         deferred = {}  # type: dict[bytes, MemPoolTx]
         unspent = set(utxo_map)
-        # Try to find all prevouts so we can accept the TX
-        for txid_rev, tx in tx_map.items():
+        # Try to find all prevouts so we can accept the candidate TXs from tx_map into our mempool
+        for txid_rev in cand_txids:
+            tx = tx_map[txid_rev]
             in_pairs = []
             try:
                 for prevout in tx.prevouts:
@@ -382,25 +401,32 @@ class MemPool:
                 tx_map.update(deferred)
                 utxo_map.update(unspent)
 
-            prior_count = 0
-            # FIXME: this is not particularly efficient.
-            #        tx_map contains candidate txs we are trying to - but haven't yet - add to our mempool.
-            #        We only accept candidates for which we can find a UTXO for each tx input:
-            #        - some UTXOs we find in the DB=utxo_map (chainstate),
-            #        - some we find in self.txs (our memool),
-            #        - some we might only find in tx_map (among the candidates: consider long chain of unconfirmed txs)
-            #        - some we might not find anywhere: if DB is corrupted or bitcoind gave inconsistent mempool, or other race
-            #        In each iteration, we loop over tx_map and move accepted transactions from it to self.txs.
-            #        In the worst degenerate case, this could be O(n^2).
-            #        Could we instead topologically sort tx_map??
-            while tx_map and len(tx_map) != prior_count:
-                prior_count = len(tx_map)
+            # Accept candidate txs from tx_map into our mempool.
+            # We only accept candidates for which we can find a UTXO for each tx input:
+            # - some UTXOs we find in the DB=utxo_map (chainstate),
+            # - some we find in self.txs (our memool),
+            # - some we might only find in tx_map (among the candidates: consider long chain of unconfirmed txs)
+            # - some we might not find anywhere: if DB is corrupted or bitcoind gave inconsistent mempool, or other race
+            # In each iteration, we loop over tx_map and move accepted transactions from it to self.txs.
+            # In the worst degenerate case, this could be O(n^2). To avoid that, we topologically sort tx_map.
+            t0 = time.monotonic()
+            first_txmap_size = len(tx_map)
+            prior_txmap_size = 0
+            iter_count = 0
+            while tx_map and len(tx_map) != prior_txmap_size:
+                prior_txmap_size = len(tx_map)
                 tx_map, utxo_map = self._accept_transactions(
                     tx_map=tx_map,
                     utxo_map=utxo_map,
                     touched_hashxs=touched_hashxs,
                     touched_outpoints=touched_outpoints,
+                    topologically_sort=True,
                 )
+                iter_count += 1
+            time_elapsed = time.monotonic() - t0
+            if time_elapsed > 0.1:
+                self.logger.debug(
+                    f'accept_transactions() while-loop took {time_elapsed:.2f}s. txs={first_txmap_size}, {iter_count=}')
             if tx_map:
                 self.logger.error(f'{len(tx_map)} txs dropped')
 

--- a/src/electrumx/server/mempool.py
+++ b/src/electrumx/server/mempool.py
@@ -232,11 +232,11 @@ class MemPool:
             self,
             *,
             tx_map: Dict[bytes, MemPoolTx],  # txid_rev->tx
-            utxo_map: Dict[Tuple[bytes, int], Tuple[bytes, int]],  # prevout->(hashX,value_in_sats)
+            utxo_map: Dict[Tuple[bytes, int], Optional[Tuple[bytes, int]]],  # prevout->(hashX,value_in_sats)
             touched_hashxs: Set[bytes],  # set of hashXs
             touched_outpoints: Set[Tuple[bytes, int]],  # set of outpoints
     ) -> Tuple[Dict[bytes, MemPoolTx],
-               Dict[Tuple[bytes, int], Tuple[bytes, int]]]:
+               Dict[Tuple[bytes, int], Optional[Tuple[bytes, int]]]]:
         '''Accept transactions in tx_map to the mempool if all their inputs
         can be found in the existing mempool or a utxo_map from the
         DB.
@@ -247,15 +247,16 @@ class MemPool:
         txs = self.txs
         txo_to_spender = self.txo_to_spender
 
-        deferred = {}
+        deferred = {}  # type: dict[bytes, MemPoolTx]
         unspent = set(utxo_map)
         # Try to find all prevouts so we can accept the TX
         for txid_rev, tx in tx_map.items():
             in_pairs = []
             try:
                 for prevout in tx.prevouts:
+                    # first, look for parent tx among confirmed UTXOs:
                     utxo = utxo_map.get(prevout)
-                    if not utxo:  # i.e. parent also unconfirmed
+                    if not utxo:  # second, look for parent tx in mempool
                         prev_hash, prev_index = prevout
                         # Raises KeyError if prev_hash is not in txs
                         utxo = txs[prev_hash].out_pairs[prev_index]
@@ -341,6 +342,7 @@ class MemPool:
             raise DBSyncError
 
         # First handle txs that have disappeared
+        # TODO split disappeared txs workload into a threadpool, chunks of ~200 txs
         for txid_rev in (set(txs) - all_txids_rev):
             tx = txs.pop(txid_rev)
             # hashXs
@@ -373,15 +375,24 @@ class MemPool:
             if mempool_height != self.api.db_height():
                 raise DBSyncError
 
-            tx_map = {}
-            utxo_map = {}
+            tx_map = {}  # type: dict[bytes, MemPoolTx]
+            utxo_map = {}  # type: dict[tuple[bytes, int], tuple[bytes, int]]
             async for task in group:
                 deferred, unspent = task.result()
                 tx_map.update(deferred)
                 utxo_map.update(unspent)
 
             prior_count = 0
-            # FIXME: this is not particularly efficient
+            # FIXME: this is not particularly efficient.
+            #        tx_map contains candidate txs we are trying to - but haven't yet - add to our mempool.
+            #        We only accept candidates for which we can find a UTXO for each tx input:
+            #        - some UTXOs we find in the DB=utxo_map (chainstate),
+            #        - some we find in self.txs (our memool),
+            #        - some we might only find in tx_map (among the candidates: consider long chain of unconfirmed txs)
+            #        - some we might not find anywhere: if DB is corrupted or bitcoind gave inconsistent mempool, or other race
+            #        In each iteration, we loop over tx_map and move accepted transactions from it to self.txs.
+            #        In the worst degenerate case, this could be O(n^2).
+            #        Could we instead topologically sort tx_map??
             while tx_map and len(tx_map) != prior_count:
                 prior_count = len(tx_map)
                 tx_map, utxo_map = self._accept_transactions(
@@ -396,11 +407,12 @@ class MemPool:
     async def _fetch_and_accept(
             self,
             *,
-            new_txids_rev: Set[bytes],  # new txs being added to mempool
-            all_txids_rev: Set[bytes],  # existing txs in mempool
+            new_txids_rev: set[bytes],  # (some) new candidate txs for our mempool
+            all_txids_rev: set[bytes],  # complete view of daemon's mempool
             touched_hashxs: Set[bytes],  # set of hashXs
             touched_outpoints: Set[Tuple[bytes, int]],  # set of outpoints
-    ):
+    ) -> tuple[dict[bytes, MemPoolTx],
+               dict[tuple[bytes, int], Optional[tuple[bytes, int]]]]:
         '''Fetch a list of mempool transactions.'''
         txids_hum_iter = (hash_to_hex_str(hash) for hash in new_txids_rev)
         raw_txs = await self.api.raw_transactions(txids_hum_iter)

--- a/src/electrumx/server/mempool.py
+++ b/src/electrumx/server/mempool.py
@@ -384,11 +384,9 @@ class MemPool:
         if new_hashes:
             group = OldTaskGroup()
             for hashes in chunks(new_hashes, 200):
-                coro = self._fetch_and_accept(
+                coro = self._fetch_raw_txs_and_utxos(
                     new_txids_rev=hashes,
                     all_txids_rev=all_txids_rev,
-                    touched_hashxs=touched_hashxs,
-                    touched_outpoints=touched_outpoints,
                 )
                 await group.spawn(coro)
             if mempool_height != self.api.db_height():
@@ -397,9 +395,9 @@ class MemPool:
             tx_map = {}  # type: dict[bytes, MemPoolTx]
             utxo_map = {}  # type: dict[tuple[bytes, int], tuple[bytes, int]]
             async for task in group:
-                deferred, unspent = task.result()
-                tx_map.update(deferred)
-                utxo_map.update(unspent)
+                partial_tx_map, partial_utxo_map = task.result()
+                tx_map.update(partial_tx_map)
+                utxo_map.update(partial_utxo_map)
 
             # Accept candidate txs from tx_map into our mempool.
             # We only accept candidates for which we can find a UTXO for each tx input:
@@ -430,16 +428,14 @@ class MemPool:
             if tx_map:
                 self.logger.error(f'{len(tx_map)} txs dropped')
 
-    async def _fetch_and_accept(
+    async def _fetch_raw_txs_and_utxos(
             self,
             *,
             new_txids_rev: set[bytes],  # (some) new candidate txs for our mempool
             all_txids_rev: set[bytes],  # complete view of daemon's mempool
-            touched_hashxs: Set[bytes],  # set of hashXs
-            touched_outpoints: Set[Tuple[bytes, int]],  # set of outpoints
     ) -> tuple[dict[bytes, MemPoolTx],
                dict[tuple[bytes, int], Optional[tuple[bytes, int]]]]:
-        '''Fetch a list of mempool transactions.'''
+        '''Fetch a list of mempool transactions, and lookup corresponding UTXOs in the DB.'''
         txids_hum_iter = (hash_to_hex_str(hash) for hash in new_txids_rev)
         raw_txs = await self.api.raw_transactions(txids_hum_iter)
 
@@ -489,12 +485,7 @@ class MemPool:
         utxos = await self.api.lookup_utxos(prevouts)
         utxo_map = {prevout: utxo for prevout, utxo in zip(prevouts, utxos)}
 
-        return self._accept_transactions(
-            tx_map=tx_map,
-            utxo_map=utxo_map,
-            touched_hashxs=touched_hashxs,
-            touched_outpoints=touched_outpoints,
-        )
+        return tx_map, utxo_map
 
     #
     # External interface

--- a/src/electrumx/server/session.py
+++ b/src/electrumx/server/session.py
@@ -43,7 +43,7 @@ from electrumx.lib.hash import (HASHX_LEN, Base58Error, hash_to_hex_str,
                                 hex_str_to_hash, sha256, double_sha256)
 from electrumx.lib.merkle import MerkleCache
 from electrumx.lib.text import sessions_lines
-from electrumx.lib.tx import TXOSpendStatus
+from electrumx.lib.tx import TXOSpendStatus, TxOutpoint
 from electrumx.server.daemon import DaemonError
 from electrumx.server.transport import PaddedRSTransport
 
@@ -287,7 +287,7 @@ class SessionManager:
             tuple[int, str | None],
             tuple[bytes | None, float | None, asyncio.Lock]
         ] = LRUCache(maxsize=1000)
-        self.oc_txo_status_cache = LRUCache(maxsize=1000)  # type: LRUCache[tuple[bytes, int], TXOSpendStatus]
+        self.oc_txo_status_cache = LRUCache(maxsize=1000)  # type: LRUCache[TxOutpoint, TXOSpendStatus]
         self.notified_height = None  # type: int | None
         self.notified_tip = None  # type: bytes | None  # block_hash_rev
         self.notified_height_changed = asyncio.Event()
@@ -1061,7 +1061,7 @@ class SessionManager:
             self,
             *,
             touched_hashxs: Set[bytes],
-            touched_outpoints: Set[Tuple[bytes, int]],
+            touched_outpoints: Set[TxOutpoint],
             height: int,
     ) -> None:
         '''Notify sessions about height changes and touched addresses.'''
@@ -1245,7 +1245,7 @@ class SessionBase(RPCSessionWithTaskGroup):
             self,
             *,
             touched_hashxs: Set[bytes],
-            touched_outpoints: Set[Tuple[bytes, int]],
+            touched_outpoints: Set[TxOutpoint],
             height_changed: bool,
     ) -> None:
         pass
@@ -1349,9 +1349,9 @@ class ElectrumX(SessionBase):
         self.subscribe_headers = False
         self.connection.max_response_size = self.env.max_send
         self.hashX_subs = {}  # type: Dict[bytes, str]  # hashX -> scripthash
-        self.txoutpoint_subs = set()  # type: Set[Tuple[bytes, int]]  # (txid_rev, txout_idx)
+        self.txoutpoint_subs = set()  # type: Set[TxOutpoint]  # (txid_rev, txout_idx)
         self.mempool_hashX_statuses = {}  # type: Dict[bytes, str]
-        self.mempool_txoutpoint_statuses = {}  # type: Dict[Tuple[bytes, int], TXOSpendStatus]
+        self.mempool_txoutpoint_statuses = {}  # type: Dict[TxOutpoint, TXOSpendStatus]
         self.set_request_handlers(self.PROTOCOL_MIN)
         self.is_peer = False
         self.cost = 5.0   # Connection cost
@@ -1422,7 +1422,7 @@ class ElectrumX(SessionBase):
             self,
             *,
             touched_hashxs: Set[bytes],
-            touched_outpoints: Set[Tuple[bytes, int]],
+            touched_outpoints: Set[TxOutpoint],
             height_changed: bool,
     ):
         """Send notifications.
@@ -1454,7 +1454,7 @@ class ElectrumX(SessionBase):
             self,
             *,
             touched_hashxs: Set[bytes],
-            touched_outpoints: Set[Tuple[bytes, int]],
+            touched_outpoints: Set[TxOutpoint],
             height_changed: bool,
     ) -> None:
         '''Notify the client about changes to touched addresses (from mempool
@@ -1503,7 +1503,7 @@ class ElectrumX(SessionBase):
         touched_outpoints = touched_outpoints.intersection(self.txoutpoint_subs)
         if touched_outpoints or (height_changed and self.mempool_txoutpoint_statuses):
             method = 'blockchain.outpoint.subscribe'
-            txo_to_status = {}  # type: dict[tuple[bytes, int], TXOSpendStatus]
+            txo_to_status = {}  # type: dict[TxOutpoint, TXOSpendStatus]
             for prevout in touched_outpoints:
                 txo_to_status[prevout] = await self.txoutpoint_status_for_notif(*prevout)  # can raise RPCError
 


### PR DESCRIPTION
some mempool work

- add comments for `process_mempool`
- `accept_transactions`:
    - topologically sort candidate txs
    - run on CPU-heavy work on separate thread, not on event loop