### PR TITLE
fix DeprecationWarning: ssl.PROTOCOL_TLS

### DIFF
--- a/src/electrumx/server/peers.py
+++ b/src/electrumx/server/peers.py
@@ -268,7 +268,10 @@ class PeerManager:
 
             kwargs = {'family': family}
             if kind == 'SSL':
-                kwargs['ssl'] = ssl.SSLContext(ssl.PROTOCOL_TLS)
+                sslc = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+                sslc.check_hostname = False
+                sslc.verify_mode = ssl.CERT_NONE
+                kwargs['ssl'] = sslc
 
             if self.env.force_proxy or peer.is_tor:
                 if not self.proxy:

--- a/src/electrumx/server/session.py
+++ b/src/electrumx/server/session.py
@@ -307,7 +307,7 @@ class SessionManager:
 
     def _ssl_context(self) -> ssl.SSLContext:
         if self._sslc is None:
-            self._sslc = ssl.SSLContext(ssl.PROTOCOL_TLS)
+            self._sslc = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
             self._sslc.load_cert_chain(self.env.ssl_certfile, keyfile=self.env.ssl_keyfile)
         return self._sslc
 


### PR DESCRIPTION
```
INFO:SessionManager:TCP server listening on 127.0.0.1:51001
/home/user/wspace/electrumx/./src/electrumx/server/session.py:310: DeprecationWarning: ssl.PROTOCOL_TLS is deprecated
  self._sslc = ssl.SSLContext(ssl.PROTOCOL_TLS)
INFO:SessionManager:SSL server listening on 127.0.0.1:51002
```

<!-- Note: Our primary focus is supporting Bitcoin, and contributions in that regard are appreciated the most!
Due to historical reasons, ElectrumX also has support for many altcoins. These will be kept as long as
maintenance burden can be kept *at a minimum*. When adding a new altcoin, (1) add a unit test (see tests/blocks),
and (2) make sure the CI tests pass. -->