### PR TITLE
mempool: call getrawmempool as soon as daemon's height changes

### DIFF
--- a/src/electrumx/server/controller.py
+++ b/src/electrumx/server/controller.py
@@ -151,6 +151,7 @@ class Controller(ServerBase):
             notifications.db_height = get_db_height
             notifications.db_height_changed = db.db_flushed_event.wait
             notifications.cached_height = daemon.cached_height
+            notifications.daemon_height_changed = daemon.height_changed.wait
             notifications.mempool_txids_hum = daemon.mempool_txids_hum
             notifications.raw_transactions = daemon.getrawtransactions
             notifications.lookup_utxos = db.lookup_utxos

--- a/src/electrumx/server/mempool.py
+++ b/src/electrumx/server/mempool.py
@@ -76,6 +76,10 @@ class MemPoolAPI(ABC):
         '''
 
     @abstractmethod
+    async def daemon_height_changed(self) -> None:
+        '''Wait until bitcoind's height changes.'''
+
+    @abstractmethod
     def db_height(self) -> int:
         '''Return the height flushed to the on-disk DB.'''
 
@@ -320,6 +324,10 @@ class MemPool:
             if height != await self.api.height():  # if height changed *again*, re-start
                 continue
             txids_rev = await run_in_thread(lambda: {hex_str_to_hash(hh) for hh in txids_hum})
+            if self.api.db_height() < height:
+                # DB not yet caught up. give it some time...
+                async with ignore_after(self.refresh_secs):
+                    await self.api.db_height_changed()
             try:
                 async with self.lock:
                     await self._process_mempool(
@@ -344,7 +352,9 @@ class MemPool:
                 touched_outpoints = set()
             # poll bitcoind's whole mempool every few seconds; or instantly after the DB height changes
             async with ignore_after(self.refresh_secs):
-                await self.api.db_height_changed()
+                async with OldTaskGroup(wait=any) as group:
+                    await group.spawn(self.api.db_height_changed())
+                    await group.spawn(self.api.daemon_height_changed())
 
     async def _process_mempool(
             self,

--- a/tests/server/test_mempool.py
+++ b/tests/server/test_mempool.py
@@ -223,6 +223,9 @@ class API(MemPoolAPI):
     async def db_height_changed(self) -> None:
         await asyncio.Event().wait()  # wait forever: fall back to polling
 
+    async def daemon_height_changed(self) -> None:
+        await asyncio.Event().wait()  # wait forever: fall back to polling
+
     def cached_height(self):
         return self._cached_height
 


### PR DESCRIPTION
- bitcoind to serve getrawmempool RPC concurrently to our BlockProcessor processing the new block
- with free-threaded python, this shaves off around 0.4 sec of the time until SessionManager.notified_height gets bumped
